### PR TITLE
Don't treat NA strings as NA values. Fixes #85

### DIFF
--- a/R/readSurvey.R
+++ b/R/readSurvey.R
@@ -63,7 +63,8 @@ readSurvey <- function(file_name,
   # import data including variable names (row 1) and variable labels (row 2)
   rawdata <- suppressMessages(readr::read_csv(file = file_name,
                              col_names = FALSE,
-                             skip = skipNr))
+                             skip = skipNr,
+                             na = c("")))
   # Need contingency when 0 rows
   assertthat::assert_that(nrow(rawdata) > 0,
                           msg="The survey you are trying to import has no responses.") # nolint


### PR DESCRIPTION
fixes #85 
Respondents occasionally supply answers of "NA" instead of skipping questions.  These answers are dropped by qualtRics because it calls readr::read_csv with the default value for the na parameter.

NOTE: setting the quoted_na to FALSE does not resolve this because the answer strings are not quoted.