### PR TITLE
Partially addressing #89, add error message for 403's

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -21,6 +21,8 @@ qualtrics_response_codes <- function(res, raw = FALSE) {
     )
   } else if(res$status_code == 401) {
     stop("Qualtrics API raised an authentication (401) error - you may not have the\nrequired authorization. Please check your API key and root url.") # nolint
+  } else if(res$status_code == 403) {
+    stop("Qualtrics API raised an forbidden (403) error - you may have a valid API\nkey that lacks permissions to query the API. Please check your settings and/or talk to your administrators.") # nolint
   } else if(res$status_code == 400) {
     stop("Qualtrics API raised a bad request (400) error - Please report this on\nhttps://github.com/ropensci/qualtRics/issues") # nolint
   } else if(res$status_code == 404) {


### PR DESCRIPTION
You get "Error in if (cnt$OK) { : argument is of length zero" if the server returns an unspecified status_code.  403 is one, associated with API permissions on otherwise valid tokens.  

Fixing this more generally would probably involve a few lines that notes if the status code doesn't fit any specified type, and returning whatever that code is for diagnostics.  Otherwise it's ambiguous.