### PR TITLE
Add GitHub link to DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,7 +21,7 @@ Description: Qualtrics <https://www.qualtrics.com/about/>
     information about the Qualtrics API. This package is
     community-maintained and is not officially supported
     by Qualtrics.
-URL: https://ropensci.github.io/qualtRics/
+URL: https://ropensci.github.io/qualtRics/, https://github.com/ropensci/qualtRics
 BugReports: https://github.com/ropensci/qualtRics/issues
 License: MIT + file LICENSE
 Encoding: UTF-8


### PR DESCRIPTION
I think it might be best to keep both, for metadata gatherers (e.g. pkgdown only adds "browse source code at" on the right if the GitHub repo is there, even if there's an issue tracker).

Btw I added the URL of the pkgdown website near the repo description :wink: 