### PR TITLE
feature(breakout_sets) added breakout_sets parameter that also exists…

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
 - Deprecate old versions of functions: `getSurveys()`, `getSurveyQuestions()`, `getSurvey()`, `readSurvey()`
 - Move to updated version of Qualtrics API (#130) thanks to @jmobrien
 - Correctly handle time zone conversions (#137) thanks to @jmobrien
+- Add `breakout_sets` parameter thanks to @shaun-jacks
 
 # qualtRics 3.1.1
 

--- a/R/fetch_survey.R
+++ b/R/fetch_survey.R
@@ -45,6 +45,10 @@
 #' values. Defaults to \code{NULL} which corresponds to UTC time. See
 #' \url{https://api.qualtrics.com/docs/time-zones} for more information on
 #' format.
+#' #' @param breakout_sets Logical. If \code{TRUE}, then the
+#' \code{\link[qualtRics]{fetch_survey}} function will split multiple
+#' choice question answers into columns. If \code{FALSE}, each multiple choice
+#' question is one column. Defaults to \code{TRUE}.
 #' @param ... Optional arguments, such as a `fileEncoding` (see `fileEncoding`
 #' argument in \code{\link[qualtRics]{read_survey}}) to import your survey using
 #' a specific encoding.
@@ -94,6 +98,7 @@ fetch_survey <- function(surveyID,
                          convert = TRUE,
                          import_id = FALSE,
                          time_zone = NULL,
+                         breakout_sets = TRUE,
                          ...) {
 
   ## Are the API credentials stored?
@@ -114,7 +119,8 @@ fetch_survey <- function(surveyID,
     unanswer_recode = unanswer_recode,
     unanswer_recode_multi = unanswer_recode_multi,
     include_display_order = include_display_order,
-    limit = limit
+    limit = limit,
+    breakout_sets = breakout_sets
   )
 
   # See if survey already in tempdir
@@ -146,7 +152,8 @@ fetch_survey <- function(surveyID,
     include_display_order = include_display_order,
     limit = limit,
     time_zone = time_zone,
-    include_questions = include_questions
+    include_questions = include_questions,
+    breakout_sets = breakout_sets
   )
 
   # SEND POST REQUEST TO API ----

--- a/R/fetch_survey.R
+++ b/R/fetch_survey.R
@@ -45,7 +45,7 @@
 #' values. Defaults to \code{NULL} which corresponds to UTC time. See
 #' \url{https://api.qualtrics.com/docs/time-zones} for more information on
 #' format.
-#' #' @param breakout_sets Logical. If \code{TRUE}, then the
+#' @param breakout_sets Logical. If \code{TRUE}, then the
 #' \code{\link[qualtRics]{fetch_survey}} function will split multiple
 #' choice question answers into columns. If \code{FALSE}, each multiple choice
 #' question is one column. Defaults to \code{TRUE}.

--- a/R/utils.R
+++ b/R/utils.R
@@ -234,6 +234,7 @@ create_fetch_url <- function(base_url, surveyID) {
 #' @param unanswer_recode_multi Flag
 #' @param include_display_order Flag
 #' @param include_questions Flag
+#' @param breakout_sets Flag
 #'
 #' @seealso See \code{\link{all_surveys}} for more details on these parameters
 #'

--- a/R/utils.R
+++ b/R/utils.R
@@ -247,7 +247,8 @@ create_raw_payload <- function(label = TRUE,
                                unanswer_recode = NULL,
                                unanswer_recode_multi = NULL,
                                include_display_order = TRUE,
-                               include_questions = NULL) {
+                               include_questions = NULL,
+                               breakout_sets = NULL) {
   paste0(
     '{"format": ', '"', "csv", '"',
     ifelse(
@@ -316,6 +317,14 @@ create_raw_payload <- function(label = TRUE,
     '"useLabels": ', tolower(label),
     ", ",
     '"includeDisplayOrder": ', tolower(include_display_order),
+    ifelse(
+      is.null(breakout_sets),
+      "",
+      paste0(
+        ', "breakoutSets": ',
+        tolower(breakout_sets)
+      )
+    ),
     "}"
   )
 }

--- a/man/create_raw_payload.Rd
+++ b/man/create_raw_payload.Rd
@@ -13,7 +13,8 @@ create_raw_payload(
   unanswer_recode = NULL,
   unanswer_recode_multi = NULL,
   include_display_order = TRUE,
-  include_questions = NULL
+  include_questions = NULL,
+  breakout_sets = NULL
 )
 }
 \arguments{
@@ -34,6 +35,8 @@ create_raw_payload(
 \item{include_display_order}{Flag}
 
 \item{include_questions}{Flag}
+
+\item{breakout_sets}{Flag}
 }
 \value{
 JSON file with options to send to API

--- a/man/fetch_survey.Rd
+++ b/man/fetch_survey.Rd
@@ -21,6 +21,7 @@ fetch_survey(
   convert = TRUE,
   import_id = FALSE,
   time_zone = NULL,
+  breakout_sets = TRUE,
   ...
 )
 }
@@ -83,6 +84,11 @@ question IDs as column names. Defaults to \code{FALSE}.}
 values. Defaults to \code{NULL} which corresponds to UTC time. See
 \url{https://api.qualtrics.com/docs/time-zones} for more information on
 format.}
+
+\item{breakout_sets}{Logical. If \code{TRUE}, then the
+\code{\link[qualtRics]{fetch_survey}} function will split multiple
+choice question answers into columns. If \code{FALSE}, each multiple choice
+question is one column. Defaults to \code{TRUE}.}
 
 \item{...}{Optional arguments, such as a `fileEncoding` (see `fileEncoding`
 argument in \code{\link[qualtRics]{read_survey}}) to import your survey using


### PR DESCRIPTION
… in API/v3 docs

This allows all multiple choice column answers to either be split to columns or collapsed to one column per multiple choice question. This saves a lot of manual data processing since it's exposed in the API. I defaulted the parameter to TRUE to stay backwards compatible with original responses. It could probably also default to NULL.