### PR TITLE
Col_types argument

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,6 +4,8 @@ Title: Download 'Qualtrics' Survey Data
 Version: 3.1.2
 Authors@R: c(person("Jasper", "Ginn", role = c("aut"),
              email = "jasperginn@gmail.com"),
+             person("Jackson", "Curtis", role = c("ctb"),
+             email = "jcurtis210@gmail.com"),
              person("Shaun", "Jackson", role = c("ctb"),
              email = "shaunbjackson@gmail.com"),
              person("Samuel", "Kaminsky", role = c("ctb"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,19 +4,19 @@ Title: Download 'Qualtrics' Survey Data
 Version: 3.1.2
 Authors@R: c(person("Jasper", "Ginn", role = c("aut"),
              email = "jasperginn@gmail.com"),
-             person("Samuel", "Kaminsky", role = c("ctb"),
-             email = "samuel.e.kaminsky@gmail.com"),
              person("Shaun", "Jackson", role = c("ctb"),
              email = "shaunbjackson@gmail.com"),
+             person("Samuel", "Kaminsky", role = c("ctb"),
+             email = "samuel.e.kaminsky@gmail.com"),
              person("Eric", "Knudsen", role = c("ctb"),
              email = "ericknud1@gmail.com"),
              person("Joseph", "O'Brien", role = c("ctb"),
              email = "joseph.obrien@utexas.edu"),
+             person("Daniel", "Seneca", role = c("ctb"),
+             email = "seneca.danielh@gmail.com"),
              person("Julia", "Silge", role = c("aut", "cre"),
              email = "julia.silge@gmail.com",
              comment = c(ORCID = "0000-0002-3671-836X")),
-             person("Daniel", "Seneca", role = c("ctb"),
-             email = "seneca.danielh@gmail.com"),
              person("Phoebe", "Wong", role = c("ctb"),
              email = "phoebe.wong@berkeley.edu")
              )

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,19 +6,19 @@ Authors@R: c(person("Jasper", "Ginn", role = c("aut"),
              email = "jasperginn@gmail.com"),
              person("Samuel", "Kaminsky", role = c("ctb"),
              email = "samuel.e.kaminsky@gmail.com"),
+             person("Shaun", "Jackson", role = c("ctb"),
+             email = "shaunbjackson@gmail.com"),
              person("Eric", "Knudsen", role = c("ctb"),
              email = "ericknud1@gmail.com"),
+             person("Joseph", "O'Brien", role = c("ctb"),
+             email = "joseph.obrien@utexas.edu"),
              person("Julia", "Silge", role = c("aut", "cre"),
              email = "julia.silge@gmail.com",
              comment = c(ORCID = "0000-0002-3671-836X")),
-             person("Phoebe", "Wong", role = c("ctb"),
-             email = "phoebe.wong@berkeley.edu"),
-             person("O'Brien", "Joseph", role = c("ctb"),
-             email = "joseph.obrien@utexas.edu"),
-             person("Seneca", "Daniel", role = c("ctb"),
+             person("Daniel", "Seneca", role = c("ctb"),
              email = "seneca.danielh@gmail.com"),
-             person("Shaun", "Jackson", role = c("ctb"),
-             email = "shaunbjackson@gmail.com")
+             person("Phoebe", "Wong", role = c("ctb"),
+             email = "phoebe.wong@berkeley.edu")
              )
 Description: Provides functions to access survey results directly into R using 
     the 'Qualtrics' API. 'Qualtrics' <https://www.qualtrics.com/about/> is an 

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 - Update `include_questions` argument to use correct name in API request.
 - Build API payloads with jsonlite (#155) thanks to @jmobrien
 - Convert tests to webmockr and vcr (#140 and #161) thanks to @shaun-jacks and @dsen6644
+- Allow user to specify column types for both `fetch_survey()` and `read_survey()` (#162) thanks to @jntrcs 
 
 # qualtRics 3.1.2
 

--- a/R/fetch_survey.R
+++ b/R/fetch_survey.R
@@ -48,6 +48,10 @@
 #' \code{\link[qualtRics]{fetch_survey}} function will split multiple
 #' choice question answers into columns. If \code{FALSE}, each multiple choice
 #' question is one column. Defaults to \code{TRUE}.
+#' @param col_types Optional. This argument provides a way to
+#' manually overwrite column types that were incorrectly guessed. Takes a cols specification.
+#' See example below and  \link[readr]{readr::cols} for formatting details. Defaults to \code{NULL}.
+#' Overwritten by \code{convert=TRUE}.
 #' @param ... Optional arguments, such as a `fileEncoding` (see `fileEncoding`
 #' argument in \code{\link[qualtRics]{read_survey}}) to import your survey using
 #' a specific encoding.
@@ -79,7 +83,9 @@
 #'   limit = 100,
 #'   label = TRUE,
 #'   unanswer_recode = 999,
-#'   verbose = TRUE
+#'   verbose = TRUE,
+#'   #Manually override EndDate to be a character vector
+#'   col_types = readr::cols(EndDate=character())
 #' )
 #' }
 #'
@@ -100,6 +106,7 @@ fetch_survey <- function(surveyID,
                          import_id = FALSE,
                          time_zone = NULL,
                          breakout_sets = TRUE,
+                         col_types = NULL,
                          ...) {
 
   if (lifecycle::is_present(last_response)) {
@@ -177,7 +184,8 @@ fetch_survey <- function(surveyID,
   # READ DATA AND SET VARIABLES ----
 
   # Read data
-  data <- read_survey(survey.fpath, import_id = import_id, time_zone = time_zone)
+  data <- read_survey(survey.fpath, import_id = import_id,
+                      time_zone = time_zone, col_types = col_types)
 
   # Add types
   if (convert & label) {

--- a/R/fetch_survey.R
+++ b/R/fetch_survey.R
@@ -85,7 +85,7 @@
 #'   unanswer_recode = 999,
 #'   verbose = TRUE,
 #'   #Manually override EndDate to be a character vector
-#'   col_types = readr::cols(EndDate=character())
+#'   col_types = readr::cols(EndDate=readr::col_character())
 #' )
 #' }
 #'

--- a/R/fetch_survey.R
+++ b/R/fetch_survey.R
@@ -48,10 +48,10 @@
 #' \code{\link[qualtRics]{fetch_survey}} function will split multiple
 #' choice question answers into columns. If \code{FALSE}, each multiple choice
 #' question is one column. Defaults to \code{TRUE}.
-#' @param col_types Optional. This argument provides a way to
-#' manually overwrite column types that were incorrectly guessed. Takes a cols specification.
-#' See example below and  \link[readr]{readr::cols} for formatting details. Defaults to \code{NULL}.
-#' Overwritten by \code{convert=TRUE}.
+#' @param col_types Optional. This argument provides a way to manually overwrite
+#' column types that may be incorrectly guessed. Takes a \code{\link[readr]{cols}}
+#' specification. See example below and \code{\link[readr]{cols}} for formatting
+#' details. Defaults to \code{NULL}. Overwritten by \code{convert = TRUE}.
 #' @param ... Optional arguments, such as a `fileEncoding` (see `fileEncoding`
 #' argument in \code{\link[qualtRics]{read_survey}}) to import your survey using
 #' a specific encoding.
@@ -84,8 +84,8 @@
 #'   label = TRUE,
 #'   unanswer_recode = 999,
 #'   verbose = TRUE,
-#'   #Manually override EndDate to be a character vector
-#'   col_types = readr::cols(EndDate=readr::col_character())
+#'   # Manually override EndDate to be a character vector
+#'   col_types = readr::cols(EndDate = readr::col_character())
 #' )
 #' }
 #'

--- a/R/read_survey.R
+++ b/R/read_survey.R
@@ -16,6 +16,9 @@
 #' format.
 #' @param legacy Logical. If \code{TRUE}, then import "legacy" format CSV files
 #' (as of 2017). Defaults to \code{FALSE}.
+#' @param col_types Optional. This argument provides a way to
+#' manually overwrite column types that were incorrectly guessed. Takes a cols specification.
+#' See example below and  \link[readr]{readr::cols} for formatting details. Defaults to \code{NULL}.
 #'
 #' @importFrom sjlabelled set_label
 #' @importFrom jsonlite fromJSON
@@ -37,12 +40,17 @@
 #' file <- system.file("extdata", "sample_legacy.csv", package = "qualtRics")
 #' df <- read_survey(file, legacy = TRUE)
 #'
+#' # Example changing column type
+#' file <- system.file("extdata", "sample.csv", package = "qualtRics")
+#' # Force EndDate to be a string
+#' df <- read_survey(file, col_types=cols(EndDate=col_character()))
 #'
 read_survey <- function(file_name,
                         strip_html = TRUE,
                         import_id = FALSE,
                         time_zone = NULL,
-                        legacy = FALSE) {
+                        legacy = FALSE,
+                        col_types = NULL) {
 
   # START UP: CHECK ARGUMENTS PASSED BY USER ----
 
@@ -137,7 +145,8 @@ read_survey <- function(file_name,
   subquestions[is.na(subquestions)] <- ""
 
   rawdata <- readr::type_convert(rawdata,
-                                 locale = readr::locale(tz = time_zone))
+                                 locale = readr::locale(tz = time_zone),
+                                 col_types = col_types)
 
   # Add labels to data
   rawdata <- sjlabelled::set_label(rawdata, unlist(subquestions))

--- a/R/read_survey.R
+++ b/R/read_survey.R
@@ -16,9 +16,10 @@
 #' format.
 #' @param legacy Logical. If \code{TRUE}, then import "legacy" format CSV files
 #' (as of 2017). Defaults to \code{FALSE}.
-#' @param col_types Optional. This argument provides a way to
-#' manually overwrite column types that were incorrectly guessed. Takes a cols specification.
-#' See example below and  \link[readr]{readr::cols} for formatting details. Defaults to \code{NULL}.
+#' @param col_types Optional. This argument provides a way to manually overwrite
+#' column types that may be incorrectly guessed. Takes a \code{\link[readr]{cols}}
+#' specification. See example below and \code{\link[readr]{cols}} for formatting
+#' details. Defaults to \code{NULL}.
 #'
 #' @importFrom sjlabelled set_label
 #' @importFrom jsonlite fromJSON
@@ -43,7 +44,7 @@
 #' # Example changing column type
 #' file <- system.file("extdata", "sample.csv", package = "qualtRics")
 #' # Force EndDate to be a string
-#' df <- read_survey(file, col_types = readr::cols(EndDate=readr::col_character()))
+#' df <- read_survey(file, col_types = readr::cols(EndDate = readr::col_character()))
 #'
 read_survey <- function(file_name,
                         strip_html = TRUE,

--- a/R/read_survey.R
+++ b/R/read_survey.R
@@ -43,7 +43,7 @@
 #' # Example changing column type
 #' file <- system.file("extdata", "sample.csv", package = "qualtRics")
 #' # Force EndDate to be a string
-#' df <- read_survey(file, col_types=cols(EndDate=col_character()))
+#' df <- read_survey(file, col_types = readr::cols(EndDate=readr::col_character()))
 #'
 read_survey <- function(file_name,
                         strip_html = TRUE,

--- a/man/fetch_survey.Rd
+++ b/man/fetch_survey.Rd
@@ -126,7 +126,7 @@ mysurvey <- fetch_survey(
   unanswer_recode = 999,
   verbose = TRUE,
   #Manually override EndDate to be a character vector
-  col_types = readr::cols(EndDate=character())
+  col_types = readr::cols(EndDate=readr::col_character())
 )
 }
 

--- a/man/fetch_survey.Rd
+++ b/man/fetch_survey.Rd
@@ -22,6 +22,7 @@ fetch_survey(
   import_id = FALSE,
   time_zone = NULL,
   breakout_sets = TRUE,
+  col_types = NULL,
   ...
 )
 }
@@ -89,6 +90,11 @@ format.}
 choice question answers into columns. If \code{FALSE}, each multiple choice
 question is one column. Defaults to \code{TRUE}.}
 
+\item{col_types}{Optional. This argument provides a way to
+manually overwrite column types that were incorrectly guessed. Takes a cols specification.
+See example below and  \link[readr]{readr::cols} for formatting details. Defaults to \code{NULL}.
+Overwritten by \code{convert=TRUE}.}
+
 \item{...}{Optional arguments, such as a `fileEncoding` (see `fileEncoding`
 argument in \code{\link[qualtRics]{read_survey}}) to import your survey using
 a specific encoding.}
@@ -118,7 +124,9 @@ mysurvey <- fetch_survey(
   limit = 100,
   label = TRUE,
   unanswer_recode = 999,
-  verbose = TRUE
+  verbose = TRUE,
+  #Manually override EndDate to be a character vector
+  col_types = readr::cols(EndDate=character())
 )
 }
 

--- a/man/fetch_survey.Rd
+++ b/man/fetch_survey.Rd
@@ -90,10 +90,10 @@ format.}
 choice question answers into columns. If \code{FALSE}, each multiple choice
 question is one column. Defaults to \code{TRUE}.}
 
-\item{col_types}{Optional. This argument provides a way to
-manually overwrite column types that were incorrectly guessed. Takes a cols specification.
-See example below and  \link[readr]{readr::cols} for formatting details. Defaults to \code{NULL}.
-Overwritten by \code{convert=TRUE}.}
+\item{col_types}{Optional. This argument provides a way to manually overwrite
+column types that may be incorrectly guessed. Takes a \code{\link[readr]{cols}}
+specification. See example below and \code{\link[readr]{cols}} for formatting
+details. Defaults to \code{NULL}. Overwritten by \code{convert = TRUE}.}
 
 \item{...}{Optional arguments, such as a `fileEncoding` (see `fileEncoding`
 argument in \code{\link[qualtRics]{read_survey}}) to import your survey using
@@ -125,8 +125,8 @@ mysurvey <- fetch_survey(
   label = TRUE,
   unanswer_recode = 999,
   verbose = TRUE,
-  #Manually override EndDate to be a character vector
-  col_types = readr::cols(EndDate=readr::col_character())
+  # Manually override EndDate to be a character vector
+  col_types = readr::cols(EndDate = readr::col_character())
 )
 }
 

--- a/man/read_survey.Rd
+++ b/man/read_survey.Rd
@@ -30,9 +30,10 @@ format.}
 \item{legacy}{Logical. If \code{TRUE}, then import "legacy" format CSV files
 (as of 2017). Defaults to \code{FALSE}.}
 
-\item{col_types}{Optional. This argument provides a way to
-manually overwrite column types that were incorrectly guessed. Takes a cols specification.
-See example below and  \link[readr]{readr::cols} for formatting details. Defaults to \code{NULL}.}
+\item{col_types}{Optional. This argument provides a way to manually overwrite
+column types that may be incorrectly guessed. Takes a \code{\link[readr]{cols}}
+specification. See example below and \code{\link[readr]{cols}} for formatting
+details. Defaults to \code{NULL}.}
 }
 \value{
 A data frame. Variable labels are stored as attributes. They are not
@@ -60,6 +61,6 @@ df <- read_survey(file, legacy = TRUE)
 # Example changing column type
 file <- system.file("extdata", "sample.csv", package = "qualtRics")
 # Force EndDate to be a string
-df <- read_survey(file, col_types = readr::cols(EndDate=readr::col_character()))
+df <- read_survey(file, col_types = readr::cols(EndDate = readr::col_character()))
 
 }

--- a/man/read_survey.Rd
+++ b/man/read_survey.Rd
@@ -60,6 +60,6 @@ df <- read_survey(file, legacy = TRUE)
 # Example changing column type
 file <- system.file("extdata", "sample.csv", package = "qualtRics")
 # Force EndDate to be a string
-df <- read_survey(file, col_types=cols(EndDate=col_character()))
+df <- read_survey(file, col_types = readr::cols(EndDate=readr::col_character()))
 
 }

--- a/man/read_survey.Rd
+++ b/man/read_survey.Rd
@@ -9,7 +9,8 @@ read_survey(
   strip_html = TRUE,
   import_id = FALSE,
   time_zone = NULL,
-  legacy = FALSE
+  legacy = FALSE,
+  col_types = NULL
 )
 }
 \arguments{
@@ -28,6 +29,10 @@ format.}
 
 \item{legacy}{Logical. If \code{TRUE}, then import "legacy" format CSV files
 (as of 2017). Defaults to \code{FALSE}.}
+
+\item{col_types}{Optional. This argument provides a way to
+manually overwrite column types that were incorrectly guessed. Takes a cols specification.
+See example below and  \link[readr]{readr::cols} for formatting details. Defaults to \code{NULL}.}
 }
 \value{
 A data frame. Variable labels are stored as attributes. They are not
@@ -52,5 +57,9 @@ df <- read_survey(file)
 file <- system.file("extdata", "sample_legacy.csv", package = "qualtRics")
 df <- read_survey(file, legacy = TRUE)
 
+# Example changing column type
+file <- system.file("extdata", "sample.csv", package = "qualtRics")
+# Force EndDate to be a string
+df <- read_survey(file, col_types=cols(EndDate=col_character()))
 
 }

--- a/tests/testthat/test-fetch-survey.R
+++ b/tests/testthat/test-fetch-survey.R
@@ -42,7 +42,8 @@ test_that("fetch_survey() returns survey with custom params", {
       unanswer_recode = 999,
       limit = 15,
       include_questions = c("QID9", "QID21"),
-      breakout_sets = FALSE
+      breakout_sets = FALSE,
+      col_types = readr::cols(EndDate=readr::col_character()),
     )
   })
 
@@ -61,6 +62,7 @@ test_that("fetch_survey() returns survey with custom params", {
                     "Q3.8 - Topic Sentiment Score",
                     "Q3.8 - Topics"))
   expect_type(x$StartDate, "double")
+  expect_type(x$EndDate, "character")
   expect_type(x$Status, "character")
   expect_type(x$`Duration (in seconds)`, "double")
   expect_type(x$Finished, "logical")

--- a/tests/testthat/test-fetch-survey.R
+++ b/tests/testthat/test-fetch-survey.R
@@ -43,7 +43,7 @@ test_that("fetch_survey() returns survey with custom params", {
       limit = 15,
       include_questions = c("QID9", "QID21"),
       breakout_sets = FALSE,
-      col_types = readr::cols(EndDate=readr::col_character()),
+      col_types = readr::cols(EndDate = readr::col_character()),
     )
   })
 

--- a/tests/testthat/test-read-survey.R
+++ b/tests/testthat/test-read-survey.R
@@ -9,28 +9,33 @@ test_that("read_survey() reads data in qualtrics standard and legacy format and 
   expect_true(is.numeric(survey$LocationLatitude))
 
   # Test if can read legacy format
-  survey_legacy <- suppressWarnings(qualtRics::read_survey("files/sample_legacy.csv", # nolint
-    legacy = TRUE
-  ))
+  survey_legacy <- suppressWarnings(
+    qualtRics::read_survey("files/sample_legacy.csv", # nolint
+                           legacy = TRUE)
+  )
   # Tests
   expect_equal(dim(survey_legacy)[1], 1)
   expect_equal(dim(survey_legacy)[2], 15)
   expect_true(is.numeric(as.numeric(survey_legacy$V8))) # StartDate
   expect_true(is.numeric(survey_legacy$LocationLatitude))
 
-  #Test if it respects col_types argument
-  survey <- suppressWarnings(qualtRics::read_survey("files/sample.csv",
-                             col_types=readr::cols(StartDate=readr::col_character())))
+  # Test if it respects col_types argument
+  survey <- suppressWarnings(
+    qualtRics::read_survey("files/sample.csv",
+                           col_types = readr::cols(StartDate = readr::col_character()))
+  )
   #Tests
   expect_equal(dim(survey)[1], 1) #Ensure no change in dims
   expect_equal(dim(survey)[2], 20) #Ensure no change in dims
   expect_true(is.character(survey$StartDate))
 
 
-  #Test if legacy version respects col_types argument
-  survey_legacy <- suppressWarnings(qualtRics::read_survey("files/sample_legacy.csv", # nolint
-                                                           legacy = TRUE,
-                                                           col_types=readr::cols(StartDate=readr::col_character())
+  # Test if legacy version respects col_types argument
+  survey_legacy <- suppressWarnings(qualtRics::read_survey(
+    "files/sample_legacy.csv", # nolint
+    legacy = TRUE,
+    col_types = readr::cols(StartDate = readr::col_character()
+    )
   ))
   # Tests
   expect_equal(dim(survey)[1], 1) #Ensure no change in dims

--- a/tests/testthat/test-read-survey.R
+++ b/tests/testthat/test-read-survey.R
@@ -17,6 +17,27 @@ test_that("read_survey() reads data in qualtrics standard and legacy format and 
   expect_equal(dim(survey_legacy)[2], 15)
   expect_true(is.numeric(as.numeric(survey_legacy$V8))) # StartDate
   expect_true(is.numeric(survey_legacy$LocationLatitude))
+
+  #Test if it respects col_types argument
+  survey <- suppressWarnings(qualtRics::read_survey("files/sample.csv",
+                             col_types=readr::cols(StartDate=readr::col_character())))
+  #Tests
+  expect_equal(dim(survey)[1], 1) #Ensure no change in dims
+  expect_equal(dim(survey)[2], 20) #Ensure no change in dims
+  expect_true(is.character(survey$StartDate))
+
+
+  #Test if legacy version respects col_types argument
+  survey_legacy <- suppressWarnings(qualtRics::read_survey("files/sample_legacy.csv", # nolint
+                                                           legacy = TRUE,
+                                                           col_types=readr::cols(StartDate=readr::col_character())
+  ))
+  # Tests
+  expect_equal(dim(survey)[1], 1) #Ensure no change in dims
+  expect_equal(dim(survey)[2], 20) #Ensure no change in dims
+  expect_true(is.character(survey$StartDate))
+
+
 })
 
 test_that("Survey exists to read from disk", {


### PR DESCRIPTION
Here is my stab at allowing people to have more control over how the data is read in. I added col_types as an argument to `read_survey()` and `fetch_survey()` (which passes it to `read_survey`).

I'm more confident in the `read_survey()` addition than `fetch_survey()`. `fetch_survey()` does conversion after it calls `read_survey()`, so it gets a little hairy about what the conversion rules hierarchy should be. I added the details in separate commits, so you can hopefully sort through them and accept only the `read_survey()` one if you wish. 

I added a couple assertions to the test cases to ensure we're getting the data types we want.