### PR TITLE
Update read_survey.R

### DIFF
--- a/R/read_survey.R
+++ b/R/read_survey.R
@@ -117,7 +117,9 @@ read_survey <- function(file_name,
       n_max = 1
     ))
 
-    names(rawdata) <- jsonlite::fromJSON(paste0('[', paste(as.character(unlist(new_ids)), collapse = ','), ']'))$ImportId
+    names(rawdata) <- jsonlite::fromJSON(
+      paste0('[', paste(as.character(unlist(new_ids)), collapse = ','), ']')
+    )$ImportId
   }
 
   # If Qualtrics adds an empty column at the end, remove it

--- a/R/read_survey.R
+++ b/R/read_survey.R
@@ -117,8 +117,7 @@ read_survey <- function(file_name,
       n_max = 1
     ))
 
-    names(rawdata) <- gsub("^\\{'ImportId': '(.*)'\\}$", "\\1",
-                           unlist(new_ids))
+    names(rawdata) <- jsonlite::fromJSON(paste0('[', paste(as.character(unlist(new_ids)), collapse = ','), ']'))$ImportId
   }
 
   # If Qualtrics adds an empty column at the end, remove it


### PR DESCRIPTION
Fix parsing of ImportIds for column names. The previous gsub wasn't capturing properly so the names were being read as JSON. But even when fixed, sometimes there are more than one element in the JSON array for each variable. This approach reliably captures all importIDs, but does rely on JSONLite.