### PR TITLE
`flatten_df` to flatten embedded data object before binding

### DIFF
--- a/R/fetch_mailinglist.R
+++ b/R/fetch_mailinglist.R
@@ -46,10 +46,12 @@ fetch_mailinglist <- function(mailinglistID){
                       language = purrr::map_chr(elements, "language", .default = NA_character_),
                       unsubscribed = purrr::map_lgl(elements, "unsubscribed", .default = NA))
 
-  x <- dplyr::bind_cols(x,
-                        purrr::flatten_df(tibble::enframe(purrr::map(elements, "embeddedData",
-                                                                     .default = NA_character_),
-                                                          name = NULL, value = "embeddedData")))
+  embeddedData <- purrr::map(elements, "embeddedData")
+  if(!all(purrr::map_lgl(embeddedData, purrr::is_empty))){
+    embeddedData <- dplyr::bind_rows(embeddedData)
+    embeddedData <- dplyr::mutate_all(embeddedData, list(~dplyr::na_if(., "")))
+    x <- dplyr::bind_cols(x, embeddedData)
+  }
 
   return(x)
 

--- a/R/fetch_mailinglist.R
+++ b/R/fetch_mailinglist.R
@@ -47,9 +47,9 @@ fetch_mailinglist <- function(mailinglistID){
                       unsubscribed = purrr::map_lgl(elements, "unsubscribed", .default = NA))
 
   x <- dplyr::bind_cols(x,
-                        tibble::enframe(purrr::map(elements, "embeddedData",
-                                                   .default = NA_character_),
-                                        name = NULL, value = "embeddedData"))
+                        purrr::flatten_df(tibble::enframe(purrr::map(elements, "embeddedData",
+                                                                     .default = NA_character_),
+                                                          name = NULL, value = "embeddedData")))
 
   return(x)
 


### PR DESCRIPTION
Embedded data fields to be individual columns rather than single list-column. This is more consistent with the mailing list export using the Qualtrics UI.