### PR TITLE
Add choiceId to `read_survey` colnames. Addresses #181.

### DIFF
--- a/R/read_survey.R
+++ b/R/read_survey.R
@@ -117,9 +117,10 @@ read_survey <- function(file_name,
       n_max = 1
     ))
 
-    names(rawdata) <- jsonlite::fromJSON(
+     name_json <- jsonlite::fromJSON(
       paste0('[', paste(as.character(unlist(new_ids)), collapse = ','), ']')
-    )$ImportId
+    )
+     names(rawdata) <- gsub("_NA", "", paste(name_json$ImportId, name_json$choiceId, sep = "_"))
   }
 
   # If Qualtrics adds an empty column at the end, remove it

--- a/R/read_survey.R
+++ b/R/read_survey.R
@@ -120,7 +120,11 @@ read_survey <- function(file_name,
      name_json <- jsonlite::fromJSON(
       paste0('[', paste(as.character(unlist(new_ids)), collapse = ','), ']')
     )
-     names(rawdata) <- gsub("_NA", "", paste(name_json$ImportId, name_json$choiceId, sep = "_"))
+     names(rawdata) <- gsub(
+       "_NA",
+       "",
+       paste(name_json$ImportId, name_json$choiceId, sep = "_")
+     )
   }
 
   # If Qualtrics adds an empty column at the end, remove it


### PR DESCRIPTION
Currently the colnames only use ImportId which will cause column name duplication. 