### PR TITLE
Add parameter `survey_definitition` to request additional survey metadata

### DIFF
--- a/R/read_survey.R
+++ b/R/read_survey.R
@@ -88,17 +88,6 @@ read_survey <- function(file_name,
     n_max = 1
   )))
 
-  # Message for no data in survey
-  if (nrow(rawdata) < 1) {
-    message("The survey you are importing has no responses.")
-    tbl <- tibble::as_tibble(matrix(nrow = 0,
-                                    ncol = length(names(header))),
-                             .name_repair = "minimal")
-    colnames(tbl) <- names(header)
-    tbl <- dplyr::mutate_all(tbl, as.character)
-    return(tbl)
-  }
-
   # MANIPULATE DATA ----
 
   # make them data.frame's, else the factor conversion
@@ -120,11 +109,26 @@ read_survey <- function(file_name,
      name_json <- jsonlite::fromJSON(
       paste0('[', paste(as.character(unlist(new_ids)), collapse = ','), ']')
     )
-     names(rawdata) <- gsub(
+
+     import_ids <- gsub(
        "_NA",
        "",
        paste(name_json$ImportId, name_json$choiceId, sep = "_")
      )
+
+     names(rawdata) <- import_ids
+  }
+
+  # Message for no data in survey
+
+  if (nrow(rawdata) < 1) {
+    message("The survey you are importing has no responses.")
+    tbl <- tibble::as_tibble(matrix(nrow = 0,
+                                    ncol = length(import_ids)),
+                             .name_repair = "minimal")
+    colnames(tbl) <- import_ids
+    tbl <- dplyr::mutate_all(tbl, as.character)
+    return(tbl)
   }
 
   # If Qualtrics adds an empty column at the end, remove it

--- a/R/utils.R
+++ b/R/utils.R
@@ -185,21 +185,21 @@ create_root_url <- function(base_url){
 }
 
 
-create_surveys_url <- function(base_url) {
+create_surveys_url <- function(base_url, survey_definition = FALSE) {
   # create surveys url
   surveys_url <-
     paste0(
       create_root_url(base_url),
-      "surveys/"
+      ifelse(survey_definition, "survey-definitions/", "surveys/")
     )
   return(surveys_url)
 }
 
-create_survey_url <- function(base_url, surveyID) {
+create_survey_url <- function(base_url, surveyID, survey_definition = FALSE) {
   # create url
   survey_url <-
     paste0(
-      create_surveys_url(base_url),
+      create_surveys_url(base_url, survey_definition),
       surveyID, "/"
     )
   return(survey_url)


### PR DESCRIPTION
This `survey-defitition` request is documented at https://api.qualtrics.com/api-reference/reference/surveyDefinitions.json/paths/~1survey-definitions~1%7BsurveyId%7D/get. 

It seems to contain more information about questions and blocks (e.g. regarding the "loop and merge" option) but also lacks a few things that are in the original "surveys" request. I added a parameter `survey_definition`` but have not added information to the function documentation or provided a default value.