### PR TITLE
Small updates to new testing procedure

### DIFF
--- a/tests/testthat/helper-qualtRics.R
+++ b/tests/testthat/helper-qualtRics.R
@@ -8,13 +8,13 @@ readRenviron("~/.Renviron")
 Sys.setenv("QUALTRICS_BASE_URL" = "www.qualtrics.com")
 
 # Set up a fake API key if none is saved
-if (Sys.getenv("QUALTRICS_API_KEY") != ""){
+if (Sys.getenv("QUALTRICS_API_KEY") == ""){
  Sys.setenv("QUALTRICS_API_KEY" = "1234")
 }
 
 # Store these for resetting later when needed
 holder_API <- Sys.getenv("QUALTRICS_API_KEY")
-holder_URL <- Sys.getenv("QUALTRICS_API_KEY")
+holder_URL <- Sys.getenv("QUALTRICS_BASE_URL")
 
   # Set directory and mask API token
 invisible(vcr::vcr_configure(

--- a/tests/testthat/helper-qualtRics.R
+++ b/tests/testthat/helper-qualtRics.R
@@ -7,7 +7,16 @@ readRenviron("~/.Renviron")
 # Use default URL rather than branded one:
 Sys.setenv("QUALTRICS_BASE_URL" = "www.qualtrics.com")
 
-# Set directory and mask API token
+# Set up a fake API key if none is saved
+if (Sys.getenv("QUALTRICS_API_KEY") != ""){
+ Sys.setenv("QUALTRICS_API_KEY" = "1234")
+}
+
+# Store these for resetting later when needed
+holder_API <- Sys.getenv("QUALTRICS_API_KEY")
+holder_URL <- Sys.getenv("QUALTRICS_API_KEY")
+
+  # Set directory and mask API token
 invisible(vcr::vcr_configure(
   dir = "../fixtures",
   preserve_exact_body_bytes = TRUE,
@@ -15,4 +24,3 @@ invisible(vcr::vcr_configure(
     list(
       "<<<my_api_key>>>" = Sys.getenv('QUALTRICS_API_KEY')
     )))
-

--- a/tests/testthat/helper-qualtRics.R
+++ b/tests/testthat/helper-qualtRics.R
@@ -15,7 +15,3 @@ invisible(vcr::vcr_configure(
     list(
       "<<<my_api_key>>>" = Sys.getenv('QUALTRICS_API_KEY')
     )))
-<<<<<<< HEAD
-=======
-
->>>>>>> Update to fix testing

--- a/tests/testthat/helper-qualtRics.R
+++ b/tests/testthat/helper-qualtRics.R
@@ -16,6 +16,12 @@ if (Sys.getenv("QUALTRICS_API_KEY") == ""){
 holder_API <- Sys.getenv("QUALTRICS_API_KEY")
 holder_URL <- Sys.getenv("QUALTRICS_BASE_URL")
 
+# NOTE: If writing new test that changes the credentials for some reason, add
+# this line (uncommented) to end of the testing file:
+# qualtrics_api_credentials(api_key = holder_API, base_url = holder_URL)
+
+
+
   # Set directory and mask API token
 invisible(vcr::vcr_configure(
   dir = "../fixtures",

--- a/tests/testthat/helper-qualtRics.R
+++ b/tests/testthat/helper-qualtRics.R
@@ -15,3 +15,7 @@ invisible(vcr::vcr_configure(
     list(
       "<<<my_api_key>>>" = Sys.getenv('QUALTRICS_API_KEY')
     )))
+<<<<<<< HEAD
+=======
+
+>>>>>>> Update to fix testing

--- a/tests/testthat/helper-qualtRics.R
+++ b/tests/testthat/helper-qualtRics.R
@@ -15,4 +15,3 @@ invisible(vcr::vcr_configure(
     list(
       "<<<my_api_key>>>" = Sys.getenv('QUALTRICS_API_KEY')
     )))
-

--- a/tests/testthat/test-all-mailinglists.R
+++ b/tests/testthat/test-all-mailinglists.R
@@ -1,7 +1,5 @@
 context("All mailing lists that the user has access to on Qualtrics")
 
-qualtrics_api_credentials(api_key = "1234", base_url = "www.qualtrics.com")
-
 test_that("all_mailinglists returns a tbl_df with expected column names and types", {
 
   vcr::use_cassette("all_mailinglists", {

--- a/tests/testthat/test-all-surveys.R
+++ b/tests/testthat/test-all-surveys.R
@@ -1,7 +1,5 @@
 context("All surveys that the user has access to on Qualtrics")
 
-qualtrics_api_credentials(api_key = "1234", base_url = "www.qualtrics.com")
-
 test_that("all_surveys() sends the proper request to Qualtrics", {
 
   vcr::use_cassette("all_surveys", {
@@ -20,12 +18,19 @@ test_that("all_surveys() sends the proper request to Qualtrics", {
 
 })
 
-qualtrics_api_credentials(api_key = "1234", base_url = "t.qualtrics.com")
 
-test_that("all_surveys() throws an error", {
+# Set to bad URL:
+qualtrics_api_credentials(api_key = holder_API,
+                          base_url = "t.qualtrics.com")
+
+test_that("all_surveys() throws an error when URL is bad", {
 
   expect_error(
     all_surveys(),
     "you may not have the\nrequired authorization"
   )
 })
+
+# Reset the URL:
+qualtrics_api_credentials(api_key = holder_API, base_url = holder_URL)
+

--- a/tests/testthat/test-all-surveys.R
+++ b/tests/testthat/test-all-surveys.R
@@ -20,10 +20,10 @@ test_that("all_surveys() sends the proper request to Qualtrics", {
 
 
 # Set to bad URL:
-qualtrics_api_credentials(api_key = holder_API,
+qualtrics_api_credentials(api_key = "1234",
                           base_url = "t.qualtrics.com")
 
-test_that("all_surveys() throws an error when URL is bad", {
+test_that("all_surveys() throws an error when URL & key is bad", {
 
   expect_error(
     all_surveys(),
@@ -31,6 +31,6 @@ test_that("all_surveys() throws an error when URL is bad", {
   )
 })
 
-# Reset the URL:
+# Reset the credentials:
 qualtrics_api_credentials(api_key = holder_API, base_url = holder_URL)
 

--- a/tests/testthat/test-api-credentials.R
+++ b/tests/testthat/test-api-credentials.R
@@ -1,5 +1,6 @@
 context("API credentials")
 
+
 test_that("absence of API key or base URL raises an error", {
   Sys.setenv("QUALTRICS_API_KEY" = "")
   Sys.setenv("QUALTRICS_BASE_URL" = "")
@@ -29,3 +30,6 @@ test_that("can store and access credentials", {
 test_that("qualtRicsConfigFile() gives a warning", {
   expect_warning(qualtRics::qualtRicsConfigFile(), "deprecated") # nolint
 })
+
+# Restore the credentials for other tests:
+qualtrics_api_credentials(api_key = holder_API, base_url = holder_URL)

--- a/tests/testthat/test-column_map.R
+++ b/tests/testthat/test-column_map.R
@@ -1,7 +1,5 @@
 context("Column mapping for one survey")
 
-qualtrics_api_credentials(api_key = "1234", base_url = "www.qualtrics.com")
-
 test_that("column_map() retrieves survey column mapping", {
 
   vcr::use_cassette("column_map", {

--- a/tests/testthat/test-download-qualtrics-export.R
+++ b/tests/testthat/test-download-qualtrics-export.R
@@ -60,3 +60,8 @@ test_that("it should make the proper export progress and download file requests"
   webmockr::stub_registry_clear()
   webmockr::disable()
 })
+
+
+# Reset the credentials:
+qualtrics_api_credentials(api_key = holder_API, base_url = holder_URL)
+

--- a/tests/testthat/test-fetch-distributions.R
+++ b/tests/testthat/test-fetch-distributions.R
@@ -1,7 +1,5 @@
 context("Fetch distribution data for a survey")
 
-qualtrics_api_credentials(api_key = "1234", base_url = "www.qualtrics.com")
-
 test_that("fetch_distributions returns a tbl_df with expected column names and types", {
 
   vcr::use_cassette("fetch_distributions", {

--- a/tests/testthat/test-fetch-mailinglist.R
+++ b/tests/testthat/test-fetch-mailinglist.R
@@ -1,7 +1,5 @@
 context("Fetch a single mailing list by ID")
 
-qualtrics_api_credentials(api_key = "1234", base_url = "www.qualtrics.com")
-
 test_that("fetch_mailinglist returns a tbl_df with expected column names and types", {
 
   vcr::use_cassette("fetch_mailinglist", {

--- a/tests/testthat/test-fetch-survey.R
+++ b/tests/testthat/test-fetch-survey.R
@@ -1,7 +1,5 @@
 context("Download a survey from qualtRics and pull it into R using the fetch_survey() function")
 
-qualtrics_api_credentials(api_key = "1234", base_url = "www.qualtrics.com")
-
 test_that("fetch_survey() returns survey with default params", {
 
   skip_on_cran()
@@ -163,4 +161,10 @@ test_that("using fetch_survey() with a base URL that doesn't end with '.qualtric
     qualtRics::fetch_survey(),
     "The Qualtrics base URL must end with"
   ) # nolint
+
+
 })
+
+# Restore the credentials for other tests:
+qualtrics_api_credentials(api_key = holder_API, base_url = holder_URL)
+

--- a/tests/testthat/test-metadata.R
+++ b/tests/testthat/test-metadata.R
@@ -1,7 +1,5 @@
 context("Get metadata for a survey")
 
-qualtrics_api_credentials(api_key = "1234", base_url = "www.qualtrics.com")
-
 test_that("metadata() should throw an error if passing invalid options to input", {
 
   expect_error(

--- a/tests/testthat/test-qualtrics-api-request.R
+++ b/tests/testthat/test-qualtrics-api-request.R
@@ -73,3 +73,6 @@ test_that("it should throw an error after certain 400 and 500 status codes", {
   webmockr::disable()
 })
 
+# Restore the credentials for other tests:
+qualtrics_api_credentials(api_key = holder_API, base_url = holder_URL)
+

--- a/tests/testthat/test-survey-questions.R
+++ b/tests/testthat/test-survey-questions.R
@@ -1,7 +1,4 @@
-
 context("Get survey questions for a survey")
-
-qualtrics_api_credentials(api_key = "1234", base_url = "www.qualtrics.com")
 
 test_that("survey_questions() makes a request with expected structure, and parses response", {
 
@@ -19,12 +16,17 @@ test_that("survey_questions() makes a request with expected structure, and parse
 
 })
 
-qualtrics_api_credentials(api_key = "1234", base_url = "t.qualtrics.com")
+# Change credentials to
+qualtrics_api_credentials(api_key = holder_API, base_url = "t.qualtrics.com")
 
-test_that("survey_questions() throws an error", {
+test_that("survey_questions() throws an error when URL is bad", {
 
   expect_error(
     qualtRics::survey_questions("1234"),
     "you may not have the\nrequired authorization"
   )
 })
+
+# Restore the credentials for other tests:
+qualtrics_api_credentials(api_key = holder_API, base_url = holder_URL)
+

--- a/tests/testthat/test-survey-questions.R
+++ b/tests/testthat/test-survey-questions.R
@@ -17,9 +17,9 @@ test_that("survey_questions() makes a request with expected structure, and parse
 })
 
 # Change credentials to
-qualtrics_api_credentials(api_key = holder_API, base_url = "t.qualtrics.com")
+qualtrics_api_credentials(api_key = "1234", base_url = "t.qualtrics.com")
 
-test_that("survey_questions() throws an error when URL is bad", {
+test_that("survey_questions() throws an error where URL & key are bad", {
 
   expect_error(
     qualtRics::survey_questions("1234"),


### PR DESCRIPTION
Suggested small extension to the PR #200 just accepted.  I think this will work even better.

Basically:

- Credentials get set in the helper file:
     - Key taken from .Renviron if existing, otherwise "1234" if missing.
     - URL is set as "www.qualtrics.com" as before.  
- Helper file creates `holder_API` and `holder_URL` for later use. 
- Removed lines setting credentials at the start of all tests, with two exceptions:
     - where specifically needed for that test (i.e., setting bad credentials)
     - older tests (pre-`vcr`/`qualtrics_api_credentials()`)
- Anywhere credentials were changed within existing tests, reset credentials from holder variables at file's end: `qualtrics_api_credentials(api_key = holder_API, base_url = holder_URL)`

This should simplify things even further:
- New test files shouldn't need to set/change the credentials unless there's some specific purpose for that.
     - Tests w/credential changes just add `qualtrics_api_credentials(api_key = holder_API, base_url = holder_URL)` at file's end to reset. 
- For vcr-based tests, the same code should now work both for the first run (for fixture generation) and subsequent tests, no changes needed.  

