### PR TITLE
fetch_survey() by survey_name

### DIFF
--- a/R/fetch_survey.R
+++ b/R/fetch_survey.R
@@ -4,6 +4,8 @@
 #'
 #' @param surveyID String. Unique ID for the survey you want to download.
 #' Returned as \code{id} by the \link[qualtRics]{all_surveys} function.
+#' @param survey_name String. Name of the survey you want to download as it
+#' appears in the Qualtrics UI.
 #' @param last_response Deprecated.
 #' @param start_date String. Filter to only exports responses recorded after the
 #' specified date. Accepts dates as character strings in format "YYYY-MM-DD".
@@ -101,7 +103,8 @@
 #'
 #' }
 #'
-fetch_survey <- function(surveyID,
+fetch_survey <- function(surveyID = NULL,
+                         survey_name = NULL,
                          last_response = deprecated(),
                          start_date = NULL,
                          end_date = NULL,
@@ -149,6 +152,26 @@ fetch_survey <- function(surveyID,
     add_column_map = add_column_map,
     add_var_labels = add_var_labels
   )
+
+  # Provide surveyID if survey_name is provided
+  if (is.null(surveyID)) {
+    if (is.null(survey_name)) {
+      stop("Please provide either a surveyID or survey_name.")
+    } else {
+      surveyID <-
+        all_surveys() %>%
+        dplyr::filter(name == survey_name) %>%
+        dplyr::pull(id)
+
+      # Check for survey name entered incorrectly or for multiple surveys with the same name.
+      if (length(surveyID) == 0) {
+        stop("No matches for survey name found - please check that you've entered a valid survey name.")
+      } else if (length(surveyID) > 1) {
+        stop("Multiple matches for this survey name found - please enter a unique surveyID instead.")
+      }
+    }
+  }
+
 
   # See if survey already in tempdir
   if (!force_request) {

--- a/man/fetch_survey.Rd
+++ b/man/fetch_survey.Rd
@@ -5,7 +5,8 @@
 \title{Download a survey and import it into R}
 \usage{
 fetch_survey(
-  surveyID,
+  surveyID = NULL,
+  survey_name = NULL,
   last_response = deprecated(),
   start_date = NULL,
   end_date = NULL,
@@ -31,6 +32,9 @@ fetch_survey(
 \arguments{
 \item{surveyID}{String. Unique ID for the survey you want to download.
 Returned as \code{id} by the \link[qualtRics]{all_surveys} function.}
+
+\item{survey_name}{String. Name of the survey you want to download as it
+appears in the Qualtrics UI.}
 
 \item{last_response}{Deprecated.}
 


### PR DESCRIPTION
Added param survey_name to fetch_survey() to allow for users to fetch_survey by the Qualtrics UI survey name, rather than the surveyID. I added a check to ensure that either surveyID or survey_name is provided, and another check for duplicate names (I'm not sure if this is allowable in the platform, but I added here just in case). surveyID is still an accepted parameter, but with the default changed to NULL. I ran a test()/test_file() call & came back w/no warnings or errors, but would be happy to make changes as needed!

This is a more fleshed-out version of a helper function I would load into my environment every time I loaded the qualtRics package - I figure it may be more beneficial to bring into the package itself. 