### PR TITLE
create fetch_distribution_history

### DIFF
--- a/R/fetch_distribution_history.R
+++ b/R/fetch_distribution_history.R
@@ -1,0 +1,58 @@
+#' Download distribution history data for a distribution from Qualtrics
+#'
+#' @param distributionID String. Unique distribution ID for the distribution history you want to download.
+#'
+#' @export
+#'
+#' @examples
+#' \dontrun{
+#' # Register your Qualtrics credentials if you haven't already
+#' qualtrics_api_credentials(
+#'   api_key = "<YOUR-API-KEY>",
+#'   base_url = "<YOUR-BASE-URL>"
+#' )
+#'
+#' surveys <- all_surveys()
+#' distributions <- fetch_distributions(surveys$id[1])
+#' distribution_history <- fetch_distribution_history(distributions$id[1])
+#'}
+#'
+
+fetch_distribution_history <- function(distributionID){
+
+  # qualtrics distribution parameters can be found at https://api.qualtrics.com/docs/getting-information-about-distributions-1#get-distribution
+
+  assert_base_url()
+  assert_api_key()
+
+  fetch_url <- generate_url(query = "fetchdistributionhistory",
+                            distributionID = distributionID)
+
+  elements <- list()
+
+  while(!is.null(fetch_url)){
+
+    res <- qualtrics_api_request("GET", url = fetch_url)
+    elements <- append(elements, res$result$elements)
+    fetch_url <- res$result$nextPage
+
+  }
+
+  elements <- res$result$elements
+
+  x <- tibble::tibble(contactId = purrr::map_chr(elements, "contactId", .default = NA_character_),
+                      contactLookupId = purrr::map_chr(elements, "contactLookupId", .default = NA_character_),
+                      distributionID = purrr::map_chr(elements, "distributionID", .default = NA_character_),
+                      status = purrr::map_chr(elements, "status", .default = NA_character_),
+                      surveyLink = purrr::map_chr(elements, "surveyLink", .default = NA_character_),
+                      contactFrequencyRuleId = purrr::map_chr(elements, "contactFrequencyRuleId", .default = NA_character_),
+                      responseId = purrr::map_chr(elements, "responseId", .default = NA_character_),
+                      responseCompletedAt = purrr::map_chr(elements, "responseCompletedAt", .default = NA_character_),
+                      sentAt = purrr::map_chr(elements, "sentAt", .default = NA_character_),
+                      openedAt = purrr::map_chr(elements, "openedAt", .default = NA_character_),
+                      responseStartedAt = purrr::map_chr(elements, "responseStartedAt", .default = NA_character_),
+                      surveySessionId = purrr::map_chr(elements, "surveySessionId", .default = NA_character_))
+
+  return(x)
+
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -221,6 +221,7 @@ generate_url <- function(query, ...){
       fetchdescription = "{rooturl}/survey-definitions/{surveyID}/",
       fetchmailinglist = "{rooturl}/mailinglists/{mailinglistID}/contacts/",
       fetchdistributions = "{rooturl}/distributions?surveyId={surveyID}",
+      fetchdistributionhistory = "{rooturl}/distributions/{distributionID}/history",
       rlang::abort("Internal error: invalid URL generation query")
     )
 


### PR DESCRIPTION
Let's break this into a few, smaller pieces. Ultimately this function isn't that useful without the distribution links in my opinion. But I'd like to get this working, and address issues with it, before adding the links.

This works. I tested it on a distribution with one invitation. Getting it to work on a distribution with a lot of invitations, and potentially doing error-handling, can be handled later.

I do want to bring attention to a 400 error I received:

> "{\"meta\":{\"requestId\":\"6d98dd48-0cd6-4a1e-994b-dccd785fc526\",\"httpStatus\":\"400 - Bad Request\",\"error\":{\"errorCode\":\"CP_TD_GER_NP\",\"errorMessage\":\"The email-distribution(REMOVED) has no recipients and no parent. This distribution type may be unsupported.\"}}}"

This distribution was some kind of test someone did. `requestType`, a column that is returned by `fetch_distributions()`, has a value of "TestEmail" whereas it is normally "Invite". Some error handling for this should be added, otherwise you get this which isn't particularly helpful:

```
> dist_hist <- fetch_distribution_history("REMOVED")
 Error: Qualtrics API raised a bad request (400) error - Please report this on
https://github.com/ropensci/qualtRics/issues
Run `rlang::last_error()` to see where the error occurred. 
> rlang::last_error()
<error/rlang_error>
Qualtrics API raised a bad request (400) error - Please report this on
https://github.com/ropensci/qualtRics/issues
Backtrace:
 1. global::fetch_distribution_history("REMOVED")
 2. qualtRics::qualtrics_api_request("GET", url = fetch_url)
 3. qualtRics::qualtrics_response_codes(res) R/utils.R:333:2
Run `rlang::last_trace()` to see the full context.
> rlang::last_trace()
<error/rlang_error>
Qualtrics API raised a bad request (400) error - Please report this on
https://github.com/ropensci/qualtRics/issues
Backtrace:
    x
 1. \-global::fetch_distribution_history("REMOVED")
 2.   \-qualtRics::qualtrics_api_request("GET", url = fetch_url)
 3.     \-qualtRics::qualtrics_response_codes(res) R/utils.R:333:2
```

For myself, I'd just know what I'm doing and document this in the function notes. I assume that ropensci would want to be a bit more formal in the approach ;)

To summarize, I'm proposing to make changes/PR in this order:
1. Merge this PR
2. Someone else address the API error (or at least help me with how it should be done)
3. I test this on larger distributions and see if it works. I suspect it might, but that it's the built-in call to distribution links that was causing my issue. If I get problems, add error handling that would automatically retry when there are transient API issues.
4. Create `fetch_distribution_links`
5. Add call to `fetch_distribution_links` to `fetch_distribution_history` as @dsen6644 originally did
6. Error-handling if necessary
