### PR TITLE
Small change to prevent converting literal "NA"s as missing.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 - Add `fetch_distribution_history()` and `list_distribution_links()` for more handling of distribution data, thanks to @chrisumphlett and @dsen6644 (#221, #239)
 
+- Changed handling of literal `"NA"` text input from users so it is no longer converted to an R `NA` value thanks to @jmobrien (#244)
+
 # qualtRics 3.1.5
 
 - Add `fetch_description()` to download complete survey description metadata from v3 API endpoint (more up-to-date than older `metadata()`) thanks to @jmobrien (#207)

--- a/R/read_survey.R
+++ b/R/read_survey.R
@@ -135,7 +135,9 @@ read_survey <- function(file_name,
     readr::type_convert(
       responsedata,
       locale = readr::locale(tz = time_zone),
-      col_types = col_types)
+      col_types = col_types,
+      na = character()
+      )
 
 
   # GENERATE COLUMN MAP ----


### PR DESCRIPTION
Set `type_convert()` to use `na = character()` to avoid converting anything further to `NA` (all suitable NAs should have been identified by the `read_csv()` call just above.)