### PR TITLE
use httr::RETRY instead of httr::VERB (#217)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 - Changed handling of literal `"NA"` text input from users so it is no longer converted to an R `NA` value thanks to @jmobrien (#244)
 
+- Use `httr::RETRY()` instead of `httr::VERB()` in `qualtrics_api_request()` to implement consistent API error-handling across all of the functions in the package. They will be retried up to 3 times if there is any error. Thanks to @chrisumphlett (#217)
+
 # qualtRics 3.1.5
 
 - Add `fetch_description()` to download complete survey description metadata from v3 API endpoint (more up-to-date than older `metadata()`) thanks to @jmobrien (#207)

--- a/R/utils.R
+++ b/R/utils.R
@@ -338,8 +338,8 @@ qualtrics_api_request <- function(verb = c("GET", "POST"),
   headers <- construct_header(Sys.getenv("QUALTRICS_API_KEY"))
   # Send request to Qualtrics API
   res <- httr::RETRY(verb,
-                    url = url,
-                    httr::add_headers(headers),
+                     url = url,
+                     httr::add_headers(headers),
                     body = body,
 					times = 4
   )

--- a/R/utils.R
+++ b/R/utils.R
@@ -340,7 +340,7 @@ qualtrics_api_request <- function(verb = c("GET", "POST"),
   res <- httr::RETRY(verb,
                      url = url,
                      httr::add_headers(headers),
-                    body = body,
+                     body = body,
 					times = 4
   )
   # Check if response type is OK

--- a/R/utils.R
+++ b/R/utils.R
@@ -337,10 +337,11 @@ qualtrics_api_request <- function(verb = c("GET", "POST"),
   # Construct header
   headers <- construct_header(Sys.getenv("QUALTRICS_API_KEY"))
   # Send request to Qualtrics API
-  res <- httr::VERB(verb,
+  res <- httr::RETRY(verb,
                     url = url,
                     httr::add_headers(headers),
-                    body = body
+                    body = body,
+					times = 4
   )
   # Check if response type is OK
   cnt <- qualtrics_response_codes(res)

--- a/tests/testthat/test-all-surveys.R
+++ b/tests/testthat/test-all-surveys.R
@@ -25,6 +25,8 @@ qualtrics_api_credentials(api_key = "1234",
 
 test_that("all_surveys() throws an error when URL & key is bad", {
 
+  skip_on_cran()
+
   expect_error(
     all_surveys(),
     "you may not have the\nrequired authorization"

--- a/tests/testthat/test-qualtrics-api-request.R
+++ b/tests/testthat/test-qualtrics-api-request.R
@@ -29,6 +29,9 @@ test_that("it should make an http request with verb, url, and api-key", {
 })
 
 test_that("it should throw an error after certain 400 and 500 status codes", {
+
+  skip_on_cran()
+
   webmockr::enable()
   mock_url <- 'https://testUrl.com'
   verb <- 'GET'


### PR DESCRIPTION
This will implement consistent error-handling across all of the api call functions in the package. They will be retried up to 3 times if there is any error.

There's an optional argument `terminate_on` that allows you to specify the statuses where this would NOT happen. This is really only relevant for 50X errors. If you have the wrong credentials, we don't need to retry. I haven't used this argument before, and the documentation doesn't specify how specific it needs to be (does "400" cover 40X?). 

Here's an example, I give a bad survey Id value to `fetch_distributions()`. It repeats the request 3 times, then uses the package's existing error handling to tell me what happened.

![image](https://user-images.githubusercontent.com/7210482/148818711-085b2972-7b4c-4910-92c8-e857c869a457.png)
