### PR TITLE
add assertion to check that URL does not start with the protocol

### DIFF
--- a/R/assertions.R
+++ b/R/assertions.R
@@ -18,7 +18,16 @@ assert_base_url <- function() {
   # Test if root URL ends with '.qualtrics.com'
   assertthat::assert_that(endsWith(Sys.getenv("QUALTRICS_BASE_URL"), ".qualtrics.com"),
                           msg = paste0(
-                            "The Qualtrics base URL must end with '.qualtrics.com'. Your base URL looks like this: '",
+                            "The Qualtrics base URL must end with '.qualtrics.com' (no trailing slash). Your base URL looks like this: '",
+                            Sys.getenv("QUALTRICS_BASE_URL"),
+                            "'.\nPlease visit https://api.qualtrics.com/docs/ for instructions about the Qualtrics base URL."
+                          )
+  )
+
+  # Test if root URL does not start with https://
+  assertthat::assert_that(!startsWith(Sys.getenv("QUALTRICS_BASE_URL"), "https://"),
+                          msg = paste0(
+                            "The Qualtrics base URL must not include the protocol ('https://'). Your base URL looks like this: '",
                             Sys.getenv("QUALTRICS_BASE_URL"),
                             "'.\nPlease visit https://api.qualtrics.com/docs/ for instructions about the Qualtrics base URL."
                           )

--- a/R/qualtrics_api_credentials.R
+++ b/R/qualtrics_api_credentials.R
@@ -12,8 +12,8 @@
 #' @param api_key The API key provided to you from Qualtrics formatted in quotes.
 #' Learn more about Qualtrics API keys at <https://api.qualtrics.com/>
 #' @param base_url The institution-specific base URL for your Qualtrics account,
-#' formatted in quotes, without the protocol (https://). Find your base URL
-#' at <https://api.qualtrics.com/>
+#' formatted in quotes, without the protocol (do not include `https://`). Find
+#' your base URL at <https://api.qualtrics.com/>
 #' @param install If TRUE, will install the key in your `.Renviron` file
 #' for use in future sessions.  Defaults to FALSE (single session use).
 #' @param overwrite If TRUE, will overwrite existing Qualtrics

--- a/R/qualtrics_api_credentials.R
+++ b/R/qualtrics_api_credentials.R
@@ -12,7 +12,8 @@
 #' @param api_key The API key provided to you from Qualtrics formatted in quotes.
 #' Learn more about Qualtrics API keys at <https://api.qualtrics.com/>
 #' @param base_url The institution-specific base URL for your Qualtrics account,
-#' formatted in quotes. Find your base URL at <https://api.qualtrics.com/>
+#' formatted in quotes, without the protocol (https://). Find your base URL
+#' at <https://api.qualtrics.com/>
 #' @param install If TRUE, will install the key in your `.Renviron` file
 #' for use in future sessions.  Defaults to FALSE (single session use).
 #' @param overwrite If TRUE, will overwrite existing Qualtrics

--- a/man/qualtrics_api_credentials.Rd
+++ b/man/qualtrics_api_credentials.Rd
@@ -16,7 +16,8 @@ qualtrics_api_credentials(
 Learn more about Qualtrics API keys at \url{https://api.qualtrics.com/}}
 
 \item{base_url}{The institution-specific base URL for your Qualtrics account,
-formatted in quotes. Find your base URL at \url{https://api.qualtrics.com/}}
+formatted in quotes, without the protocol (https://). Find your base URL
+at \url{https://api.qualtrics.com/}}
 
 \item{overwrite}{If TRUE, will overwrite existing Qualtrics
 credentials that you already have in your \code{.Renviron} file.}

--- a/man/qualtrics_api_credentials.Rd
+++ b/man/qualtrics_api_credentials.Rd
@@ -16,8 +16,8 @@ qualtrics_api_credentials(
 Learn more about Qualtrics API keys at \url{https://api.qualtrics.com/}}
 
 \item{base_url}{The institution-specific base URL for your Qualtrics account,
-formatted in quotes, without the protocol (https://). Find your base URL
-at \url{https://api.qualtrics.com/}}
+formatted in quotes, without the protocol (do not include \verb{https://}). Find
+your base URL at \url{https://api.qualtrics.com/}}
 
 \item{overwrite}{If TRUE, will overwrite existing Qualtrics
 credentials that you already have in your \code{.Renviron} file.}

--- a/qualtRics.Rproj
+++ b/qualtRics.Rproj
@@ -17,5 +17,6 @@ StripTrailingWhitespace: Yes
 
 BuildType: Package
 PackageUseDevtools: Yes
+PackageCleanBeforeInstall: Yes
 PackageInstallArgs: --no-multiarch --with-keep.source
 PackageRoxygenize: rd,collate,namespace,vignette

--- a/tests/testthat/test-api-credentials.R
+++ b/tests/testthat/test-api-credentials.R
@@ -21,6 +21,13 @@ test_that("can store and access credentials", {
     assert_base_url(),
     "The Qualtrics base URL must end with"
   )
+
+  qualtrics_api_credentials(api_key = "1234", base_url = "https://abcd.qualtrics.com")
+  expect_error(
+    assert_base_url(),
+    "The Qualtrics base URL must not include"
+  )
+
   qualtrics_api_credentials(api_key = "1234", base_url = "abcd.qualtrics.com")
   # Now expect this to be true
   expect_true(assert_api_key())


### PR DESCRIPTION
addresses #257 

I also added a little info about not including the protocol to the documentation of `qualtrics_api_credentials`