### PR TITLE
bugfix for datacenter URL checking

### DIFF
--- a/R/checks.R
+++ b/R/checks.R
@@ -52,7 +52,7 @@ checkarg_base_url <- function(base_url){
   }
   # Remove trailing '/' if present (silently), and check for qualtrics.com ending:
   if(endsWith(base_url, "qualtrics.com/")){
-    base_url <- stringr::str_remove(base_url, "/$", "")
+    base_url <- stringr::str_remove(base_url, "/$")
   } else if (!endsWith(base_url, ".qualtrics.com")){
     rlang::abort(
       c("Error in argument `base_url`",

--- a/tests/testthat/test-api-credentials.R
+++ b/tests/testthat/test-api-credentials.R
@@ -18,16 +18,29 @@ test_that("can store and access credentials", {
     "`base_url` must be of the form"
   )
 
-  qualtrics_api_credentials(api_key = "1234", base_url = "https://abcd.qualtrics.com")
+  # Removes protocol with message
+  expect_message(
+    qualtrics_api_credentials(api_key = "1234",
+                              base_url = "https://abcd.qualtrics.com"),
+    "Protocol"
+  )
   expect_false(
     startsWith(Sys.getenv("QUALTRICS_BASE_URL" ), "https://")
   )
 
+  # Removes the trailing slash:
+  qualtrics_api_credentials(api_key = "1234", base_url = "abcd.qualtrics.com/")
+  # Now expect this to no longer have slash
+  expect_false(
+    endsWith(Sys.getenv("QUALTRICS_BASE_URL" ), "/")
+  )
+
+  # Checks pass with correct credentials:
   qualtrics_api_credentials(api_key = "1234", base_url = "abcd.qualtrics.com")
-  # Now expect this to be true
+  # Now expect this to be NULL
   expect_null(
     check_credentials()
-    )
+  )
 })
 
 test_that("qualtRicsConfigFile() gives a warning", {


### PR DESCRIPTION
Small error in how the argument checking handles the removal of trailing slashes in base_url