### PR TITLE
add list_directories, list_mailing_lists, and mailing_list_contacts

### DIFF
--- a/R/list_directories.R
+++ b/R/list_directories.R
@@ -1,0 +1,40 @@
+#' Retrieve a data frame of all directories from Qualtrics
+#'
+#' @template retry-advice
+#' @export
+#'
+#' @examples
+#' \dontrun{
+#' # Register your Qualtrics credentials if you haven't already
+#' qualtrics_api_credentials(
+#'   api_key = "<YOUR-API-KEY>",
+#'   base_url = "<YOUR-BASE-URL>"
+#' )
+#'
+#' # Retrieve a list of all directories
+#' directories <- list_directories()
+#' }
+#'
+
+list_directories <- function(){
+
+  check_credentials()
+
+  # Function-specific API stuff
+  fetch_url <- generate_url(query = "listdirectories")
+
+  elements <- list()
+
+  while(!is.null(fetch_url)){
+
+    res <- qualtrics_api_request("GET", url = fetch_url)
+    elements <- append(elements, res$result$elements)
+    fetch_url <- res$result$nextPage
+
+  }
+
+  x <- purrr::map_df(elements, purrr::flatten)
+
+  return(x)
+
+}

--- a/R/list_mailing_lists.R
+++ b/R/list_mailing_lists.R
@@ -1,0 +1,51 @@
+
+#' Retrieve a data frame of all mailing lists for a directory from Qualtrics
+#'
+#' @param directoryID String. Unique directory ID.
+#'
+#' @template retry-advice
+#' @export
+#'
+#' @examples
+#' \dontrun{
+#' # Register your Qualtrics credentials if you haven't already
+#' qualtrics_api_credentials(
+#'   api_key = "<YOUR-API-KEY>",
+#'   base_url = "<YOUR-BASE-URL>"
+#' )
+#'
+#' directories <- list_directories()
+#' mailing_lists <- list_mailing_lists(directories$directoryId[1])
+#'}
+#'
+
+list_mailing_lists <- function(directoryID){
+
+  # qualtrics list mailing lists parameters can be found at
+  # https://api.qualtrics.com/dd83f1535056c-list-mailing-lists
+
+  check_credentials()
+  checkarg_isstring(directoryID)
+
+  fetch_url <- generate_url(query = "listmailinglists",
+                            directoryID = directoryID)
+
+  elements <- list()
+
+  while(!is.null(fetch_url)){
+
+    res <- qualtrics_api_request("GET", url = fetch_url)
+    elements <- append(elements, res$result$elements)
+    fetch_url <- res$result$nextPage
+
+  }
+
+  x <- tibble::tibble(mailingListId = purrr::map_chr(elements, "mailingListId", .default = NA_character_),
+                      name = purrr::map_chr(elements, "name", .default = NA_character_),
+                      ownerId = purrr::map_chr(elements, "ownerId", .default = NA_character_),
+                      lastModifiedDate = purrr::map_chr(elements, "lastModifiedDate", .default = NA_character_),
+                      creationDate = purrr::map_chr(elements, "creationDate", .default = NA_character_),
+                      contactCount = purrr::map_chr(elements, "contactCount", .default = NA_character_))
+  return(x)
+
+}

--- a/R/mailing_list_contacts.R
+++ b/R/mailing_list_contacts.R
@@ -1,0 +1,57 @@
+
+#' Retrieve a data frame of all contacts for a mailing list from Qualtrics
+#'
+#' @param directoryID String. Unique directory ID.
+#' @param mailinglistID String. Unique ID of mailing list you want contacts from.
+#'
+#' @template retry-advice
+#' @export
+#'
+#' @examples
+#' \dontrun{
+#' # Register your Qualtrics credentials if you haven't already
+#' qualtrics_api_credentials(
+#'   api_key = "<YOUR-API-KEY>",
+#'   base_url = "<YOUR-BASE-URL>"
+#' )
+#'
+#' directories <- list_directories()
+#' mailing_lists <- list_mailing_lists(directories$directoryId[1])
+#' contacts <- mailing_list_contacts(mailing_lists$mailingListId[1])
+#'}
+#'
+
+mailing_list_contacts <- function(directoryID, mailinglistID){
+
+  # qualtrics mailing lists contacts parameters can be found at
+  # https://api.qualtrics.com/af95194dd116e-list-contacts-in-mailing-list
+
+  check_credentials()
+  checkarg_isstring(directoryID)
+  checkarg_isstring(mailinglistID)
+
+  fetch_url <- generate_url(query = "mailinglistcontacts",
+                            directoryID = directoryID,
+                            mailinglistID = mailinglistID)
+
+  elements <- list()
+
+  while(!is.null(fetch_url)){
+
+    res <- qualtrics_api_request("GET", url = fetch_url)
+    elements <- append(elements, res$result$elements)
+    fetch_url <- res$result$nextPage
+
+  }
+
+  x <- tibble::tibble(contactId = purrr::map_chr(elements, "contactId", .default = NA_character_),
+                      firstName = purrr::map_chr(elements, "firstName", .default = NA_character_),
+                      lastName = purrr::map_chr(elements, "lastName", .default = NA_character_),
+                      email = purrr::map_chr(elements, "email", .default = NA_character_),
+                      phone = purrr::map_chr(elements, "phone", .default = NA_character_),
+                      extRef = purrr::map_chr(elements, "extRef", .default = NA_character_),
+                      language = purrr::map_chr(elements, "language", .default = NA_character_),
+                      unsubscribed = purrr::map_lgl(elements, "unsubscribed", .default = NA_character_))
+  return(x)
+
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -153,6 +153,9 @@ generate_url <-
         fetchdistributions = "{rooturl}/distributions?surveyId={surveyID}",
         fetchdistributionhistory = "{rooturl}/distributions/{distributionID}/history",
         listdistributionlinks = "{rooturl}/distributions/{distributionID}/links?surveyId={surveyID}",
+        listdirectories = "{rooturl}/directories",
+        listmailinglists = "{rooturl}/directories/{directoryID}/mailinglists",
+        mailinglistcontacts = "{rooturl}/directories/{directoryID}/mailinglists/{mailinglistID}/contacts",
         rlang::abort("Internal error: invalid URL generation query")
       )
 


### PR DESCRIPTION
`list_mailing_lists` will replace `all_mailinglists`, `mailing_list_contacts` will replace `fetch_mailinglist`.

Mailing list pulls now require the directory id associated with the mailing list.

Unit testing is still needed (I'll need some directions, haven't used the VCR package in a while), but I wanted to get other developers to test these new functions first. 

Should close #271 