### PR TITLE
Add query argument to qualtrics_api_request()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -51,4 +51,4 @@ VignetteBuilder:
 Encoding: UTF-8
 LazyData: FALSE
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.1
+RoxygenNote: 7.2.2

--- a/R/utils.R
+++ b/R/utils.R
@@ -219,27 +219,46 @@ create_raw_payload <-
 qualtrics_api_request <-
   function(verb = c("GET", "POST"),
            url = url,
+           query = NULL,
            body = NULL,
-           as = c("parsed", "raw"),
+           as = c("parsed", "raw", "text"),
            ...
            ) {
     # Match args
     verb <- rlang::arg_match(verb)
     as <- rlang::arg_match(as)
     # Construct header
-    headers <- construct_header(
-      Sys.getenv("QUALTRICS_API_KEY")
-    )
+    headers <-
+      construct_header(
+        Sys.getenv("QUALTRICS_API_KEY")
+      )
+
+    # Prepare list of args:
+    arglist <-
+      list(
+        verb = verb,
+        url = url,
+        config = httr::add_headers(headers),
+        body = body,
+        times = 4,
+        terminate_on = 400:451,
+        quiet = TRUE
+      )
+
+    # if needed, add query arg in proper place:
+    # (adding query = NULL directly breaks some requests)
+    if(!is.null(query)){
+      arglist <-
+        append(x = arglist,
+               values = list(query = query),
+               after = 3
+        )
+    }
+
     # Send request to Qualtrics API
-    res <- httr::RETRY(
-      verb,
-      url = url,
-      httr::add_headers(headers),
-      body = body,
-      times = 4,
-      terminate_on = 400:451,
-      quiet = TRUE
-    )
+    res <-
+      do.call(httr::RETRY, arglist)
+
     # Check if response type is OK
     qualtrics_response_codes(res)
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -209,6 +209,7 @@ create_raw_payload <-
 #'
 #' @param verb Type of request to be sent (@seealso [httr::VERB()])
 #' @param url Qualtrics endpoint URL created by [generate_url()] functions
+#' @param query Optional query parameters used by some endpoints
 #' @param body Options created by [create_raw_payload()] function
 #' @param as type of content to return, passed to `as` in httr::content().
 #' current options "parsed" (since we get JSON mostly), "raw" (response .zips)
@@ -221,7 +222,7 @@ qualtrics_api_request <-
            url = url,
            query = NULL,
            body = NULL,
-           as = c("parsed", "raw", "text"),
+           as = c("parsed", "raw"),
            ...
            ) {
     # Match args

--- a/man/qualtrics_api_request.Rd
+++ b/man/qualtrics_api_request.Rd
@@ -7,6 +7,7 @@
 qualtrics_api_request(
   verb = c("GET", "POST"),
   url = url,
+  query = NULL,
   body = NULL,
   as = c("parsed", "raw"),
   ...
@@ -16,6 +17,8 @@ qualtrics_api_request(
 \item{verb}{Type of request to be sent (@seealso \code{\link[httr:VERB]{httr::VERB()}})}
 
 \item{url}{Qualtrics endpoint URL created by \code{\link[=generate_url]{generate_url()}} functions}
+
+\item{query}{Optional query parameters used by some endpoints}
 
 \item{body}{Options created by \code{\link[=create_raw_payload]{create_raw_payload()}} function}
 


### PR DESCRIPTION
Addition of support for "query" parameter into `qualtrics_api_request()`.  This is used by several endpoints, and so will support further development on those.  

PR #275 (where the need for this first was identified) has commit a6f428d (mine) that attempts to address this a different way.  However, this created problems--for endpoints that accept a query param, passing an explicit `query = NULL` produced issues (e.g., with `all_surveys()`.  This avoids that by not including query in the request unless a non-null value is given, preserving the previous, functional request configuration otherwise.  Working in problem spaces according to tests so far.  

PR #275 should now be able to continue.  However, it should be adjusted to incorporate this change, plus commit a6f428d should be removed.  

