### PR TITLE
patching fetch_mailinglist when "unsubscribed"  is string "true"/"false"

### DIFF
--- a/R/fetch_mailinglist.R
+++ b/R/fetch_mailinglist.R
@@ -57,6 +57,11 @@ fetch_mailinglist <- function(mailinglistID){
 
   embeddedData <- purrr::map(elements, "embeddedData")
   if(!all(purrr::map_lgl(embeddedData, purrr::is_empty))){
+    # Blank fill if entry lacking embedded data (avoids row mismatch in bind_cols):
+    fill_var_name <- names(bind_rows(embeddedData))[1]
+    fill_var <- setNames(list(NA_character_), fill_var_name)
+    embeddedData <- map(embeddedData, ~.x %||% fill_var)
+
     embeddedData <- dplyr::bind_rows(embeddedData)
     embeddedData <- dplyr::mutate_all(embeddedData, list(~dplyr::na_if(., "")))
     x <- dplyr::bind_cols(x, embeddedData)

--- a/R/fetch_mailinglist.R
+++ b/R/fetch_mailinglist.R
@@ -42,13 +42,18 @@ fetch_mailinglist <- function(mailinglistID){
 
   }
 
-  x <- tibble::tibble(id = purrr::map_chr(elements, "id", .default = NA_character_),
-                      firstName = purrr::map_chr(elements, "firstName", .default = NA_character_),
-                      lastName = purrr::map_chr(elements, "lastName", .default = NA_character_),
-                      email = purrr::map_chr(elements, "email", .default = NA_character_),
-                      externalDataReference = purrr::map_chr(elements, "externalDataReference", .default = NA_character_),
-                      language = purrr::map_chr(elements, "language", .default = NA_character_),
-                      unsubscribed = purrr::map_lgl(elements, "unsubscribed", .default = NA))
+  elements <-
+    purrr::map(elements, ~purrr::modify_in(.x, "unsubscribed", as.logical))
+
+  x <- tibble::tibble(
+    id = purrr::map_chr(elements, "id", .default = NA_character_),
+    firstName = purrr::map_chr(elements, "firstName", .default = NA_character_),
+    lastName = purrr::map_chr(elements, "lastName", .default = NA_character_),
+    email = purrr::map_chr(elements, "email", .default = NA_character_),
+    externalDataReference = purrr::map_chr(elements, "externalDataReference", .default = NA_character_),
+    language = purrr::map_chr(elements, "language", .default = NA_character_),
+    unsubscribed = purrr::map_lgl(elements, "unsubscribed", .default = NA)
+    )
 
   embeddedData <- purrr::map(elements, "embeddedData")
   if(!all(purrr::map_lgl(embeddedData, purrr::is_empty))){


### PR DESCRIPTION
Addresses #304, and comment in #275

Should smooth over this strange situation (that multiple people have encountered) without compromising existing function.  

Not ideal but should serve until function is replaced with new versions (#275)