### PR TITLE
Change to `include_na = FALSE` in `wrapper_mc()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # qualtRics (development version)
 
+- Changed how multiple choice questions are mapped to an R factor with the `convert` argument to `fetch_survey()`, to now excluding `NA` as a factor level
+
 # qualtRics 3.1.7
 
 - Refactored code for checking arguments and errors, thanks to @jmobrien (#263)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # qualtRics (development version)
 
-- Changed how multiple choice questions are mapped to an R factor with the `convert` argument to `fetch_survey()`, to now excluding `NA` as a factor level
+- Changed how multiple choice questions are mapped to an R factor with the `convert` argument to `fetch_survey()`, to now excluding `NA` as a factor level (#315)
 
 # qualtRics 3.1.7
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -370,8 +370,8 @@ wrapper_mc <- function(data, question_meta) {
     !!col_name := as.character(!!col_name),
     !!col_name := readr::parse_factor(!!col_name,
                                       levels = ln,
-                                      ordered = TRUE
-    )
+                                      ordered = TRUE,
+                                      include_na = FALSE)
   )
 }
 


### PR DESCRIPTION
Closes #240 

This PR changes how answers to multiple choice questions are mapped to an R factor, to now _exclude_ `NA` values from the factor levels.