### PR TITLE
Feature/enhance survey questions

### DIFF
--- a/R/get_response.R
+++ b/R/get_response.R
@@ -19,13 +19,13 @@ get_response <- function(surveyID,
   # Send GET request to list all surveys
   resp <- qualtrics_api_request("GET", surveys_url)
   # Put results in list
-  master <- list()
+  #   master <- list()
   # Append results
-  master <- append(master, resp$result$elements)
+  #   master <- append(master, resp$result$elements)
 
   # WRAP-UP AND RETURN ----
 
   # Bind to one large data frame & return
-  d <- bind_rows(master)
-  return(d)
+  #   d <- bind_rows(master)
+  return(master)
 }

--- a/R/get_response.R
+++ b/R/get_response.R
@@ -27,5 +27,5 @@ get_response <- function(surveyID,
 
   # Bind to one large data frame & return
   #   d <- bind_rows(master)
-  return(master)
+  return(resp)
 }

--- a/R/get_response.R
+++ b/R/get_response.R
@@ -1,6 +1,7 @@
 # Get individual responses
 
-get_response <- function() {
+get_response <- function(surveyID,
+                        responseID) {
 
   # CHECK PARAMS AND PREP QUERY ----
 

--- a/R/get_response.R
+++ b/R/get_response.R
@@ -1,0 +1,28 @@
+# Get individual responses
+
+get_response <- function() {
+
+  # CHECK PARAMS AND PREP QUERY ----
+
+  # Check params
+  assert_base_url()
+  assert_api_key()
+
+  # Function-specific API stuff
+  surveys_url <- generate_url(query = "response")
+
+  # SEND REQUEST TO QUALTRICS ----
+
+  # Send GET request to list all surveys
+  resp <- qualtrics_api_request("GET", surveys_url)
+  # Put results in list
+  master <- list()
+  # Append results
+  master <- append(master, resp$result$elements)
+
+  # WRAP-UP AND RETURN ----
+
+  # Bind to one large data frame & return
+  d <- bind_rows(master)
+  return(d)
+}

--- a/R/get_response.R
+++ b/R/get_response.R
@@ -10,7 +10,9 @@ get_response <- function(surveyID,
   assert_api_key()
 
   # Function-specific API stuff
-  surveys_url <- generate_url(query = "response")
+  surveys_url <- generate_url(query = "response",
+                             surveyID = surveyID,
+                             responseID = responseID)
 
   # SEND REQUEST TO QUALTRICS ----
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -217,6 +217,7 @@ generate_url <- function(query, ...){
       allsurveys = "{rooturl}/surveys/",
       allmailinglists = "{rooturl}/mailinglists/",
       metadata = "{rooturl}/surveys/{surveyID}/",
+      response = "{rooturl}/surveys/{surveyID}/responses/{responseID}",
       fetchsurvey = "{rooturl}/surveys/{surveyID}/export-responses/",
       fetchdescription = "{rooturl}/survey-definitions/{surveyID}/",
       fetchmailinglist = "{rooturl}/mailinglists/{mailinglistID}/contacts/",


### PR DESCRIPTION
I think it would be really useful to be able to see the question block and the response options when getting the questions. With this change, the survey_questions function displays the name of the question block and a concatenated version of the response options. The concatenation isn't ideal but I couldn't think of a better way to keep the output tidy.