### PR TITLE
Handle ordered factor when multiple choice question uses recoded variable names

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # qualtRics (development version)
 
+- Fixed bug when a survey question has *both* recoded values and variable naming thanks to @Haunfelder (#343)
+
 # qualtRics 3.2.0
 
 - Changed how multiple choice questions are mapped to an R factor with the `convert` argument to `fetch_survey()`, to now excluding `NA` as a factor level (#315)

--- a/R/utils.R
+++ b/R/utils.R
@@ -359,8 +359,14 @@ wrapper_mc <- function(data, question_meta) {
 
   # Level names
   ln <- dplyr::pull(dplyr::mutate(meta,
-                                  meta_levels = purrr::map_chr(value,
-                                                               "choiceText")),
+                                  meta_levels = ifelse(
+                                    purrr::map(value, function(x){is.null(x$variableName)}),
+                                    purrr::map_chr(value,
+                                                         "choiceText"),
+                                    purrr::map_chr(value,
+                                                   "variableName")
+                                    )
+                                 ),
                     meta_levels)
   ln <- remove_html(ln)
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -358,16 +358,18 @@ wrapper_mc <- function(data, question_meta) {
   meta <- tibble::enframe(question_meta$choices)
 
   # Level names
-  ln <- dplyr::pull(dplyr::mutate(meta,
-                                  meta_levels = ifelse(
-                                    purrr::map(value, function(x){is.null(x$variableName)}),
-                                    purrr::map_chr(value,
-                                                         "choiceText"),
-                                    purrr::map_chr(value,
-                                                   "variableName")
-                                    )
-                                 ),
-                    meta_levels)
+ln <-
+  dplyr::pull(
+    dplyr::mutate(meta,
+      meta_levels = ifelse(
+        purrr::map(value, function(x) is.null(x$variableName)),
+        purrr::map_chr(value, "choiceText"),
+        purrr::map_chr(value, "variableName")
+      )
+    ),
+    meta_levels
+  )
+
   ln <- remove_html(ln)
 
   # Convert


### PR DESCRIPTION
If variableNames are non-null, use them for factor levels, otherwise use the choiceText. It may be more appropriate to add an explicit flag to the function to not cause any issues with people relying on choiceText. From my testing, all cases where variableNames do not match choiceText causes an error in fetch_survey as explained in the issue. 

Fixes #342 

