### PR TITLE
Use `archive::archive_extract()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,6 +25,7 @@ URL: https://docs.ropensci.org/qualtRics/,
     https://github.com/ropensci/qualtRics
 BugReports: https://github.com/ropensci/qualtRics/issues
 Imports:
+    archive,
     cli,
     dplyr (>= 1.0),
     fs,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # qualtRics (development version)
 
 - Fixed bug when a survey question has *both* recoded values and variable naming thanks to @Haunfelder (#343)
+- Changed how CSV files are extracted from the Qualtrics zip archive, to handle special characters in survey titles (#349)
 
 # qualtRics 3.2.0
 

--- a/R/fetch_survey.R
+++ b/R/fetch_survey.R
@@ -480,9 +480,7 @@ export_responses_progress <-
 #' @importFrom utils unzip
 #' @keywords internal
 export_responses_filedownload <-
-  function(surveyID,
-           fileID,
-           tmp_dir){
+  function(surveyID, fileID, tmp_dir){
 
     # Clean up zip file (for security)
     zip_path <- fs::file_temp(ext = "zip", tmp_dir = tmp_dir)
@@ -524,27 +522,18 @@ export_responses_filedownload <-
       )
     }
 
-
-    # Make connection to zip file:
-    zipcon <-
-      unz(
-        description = zip_path,
-        filename = csv_filename,
-        open = "rb"
-      )
+    # Extract CSV from zip file:
+    archive::archive_extract(zip_path, tmp_dir, csv_filename)
 
     # Read in raw data:
     rawdata <-
       suppressMessages(
         readr::read_csv(
-          file = zipcon,
+          file = fs::path(tmp_dir, csv_filename),
           col_types = readr::cols(.default = readr::col_character()),
           na = c("")
         )
       )
-
-    # Close connection:
-    close(zipcon)
 
     # Return raw data:
     return(rawdata)


### PR DESCRIPTION
Closes #195 
Closes #329 
Closes #345 
Closes #348 

This PR switches over to using [archive](https://archive.r-lib.org/reference/archive_extract.html) instead of the base R `unz()`. You can [check out my example survey](https://conjoint.qualtrics.com/jfe/form/SV_8333HU7pajrPy0C), which has the title `"new: survey! about? ~benefits~"`.

This PR can be installed via `devtools::install_github("ropensci/qualtRics@use-archive-extract")` to test it out.