### PR TITLE
Extract whole archive, to avoid problems with special characters

### DIFF
--- a/R/fetch_survey.R
+++ b/R/fetch_survey.R
@@ -523,7 +523,7 @@ export_responses_filedownload <-
     }
 
     # Extract CSV from zip file:
-    archive::archive_extract(zip_path, tmp_dir, csv_filename)
+    archive::archive_extract(zip_path, tmp_dir)
 
     # Read in raw data:
     rawdata <-


### PR DESCRIPTION
Closes #354 

It turns out that if we try to do:

```r
archive::archive_extract(zip_path, tmp_dir, csv_filename)
```

with a `csv_filename` with special characters in the name, nothing happens; somehow `archive_extract` does not find the file. This may be related to https://github.com/r-lib/archive/issues/75.

In our case, I don't think there is any harm in just extracting the whole archive; it is in the temp directory and I've never seen anything in the zip archives from Qualtrics but the CSV file themselves. With the change in this PR, the CSV does get extracted and then I can access it via `fs::path(tmp_dir, csv_filename)`.