### PR TITLE
Replace `surveys$id[i]` with `"SV_xxxxxxx1"` to close #341

### DIFF
--- a/R/all_surveys.R
+++ b/R/all_surveys.R
@@ -17,10 +17,10 @@
 #' surveys <- all_surveys()
 #'
 #' # Retrieve a single survey
-#' mysurvey <- fetch_survey(surveyID = surveys$id[6])
+#' mysurvey <- fetch_survey(surveyID = "SV_xxxxxxx1")
 #'
 #' mysurvey <- fetch_survey(
-#'   surveyID = surveys$id[6],
+#'   surveyID = "SV_xxxxxxx1",
 #'   save_dir = tempdir(),
 #'   start_date = "2018-01-01",
 #'   end_date = "2018-01-31",

--- a/R/column_map.R
+++ b/R/column_map.R
@@ -19,11 +19,11 @@
 #' surveys <- all_surveys()
 #'
 #' # Retrieve column mapping for a survey
-#' mapping <- column_map(surveyID = surveys$id[6])
+#' mapping <- column_map(surveyID = "SV_xxxxxxx1")
 #'
 #' # Retrieve a single survey, filtering for specific questions
 #' mysurvey <- fetch_survey(
-#'   surveyID = surveys$id[6],
+#'   surveyID = "SV_xxxxxxx1",
 #'   save_dir = tempdir(),
 #'   include_questions = c("QID1", "QID2", "QID3"),
 #'   verbose = TRUE

--- a/R/extract_colmap.R
+++ b/R/extract_colmap.R
@@ -16,7 +16,7 @@
 #' surveys <- all_surveys()
 #'
 #' # Retrieve a single survey
-#' mysurvey <- fetch_survey(surveyID = surveys$id[6])
+#' mysurvey <- fetch_survey(surveyID = "SV_xxxxxxx1")
 #'
 #' # Extract column mapping for survey
 #' extract_colmap(mysurvey)

--- a/R/fetch_description.R
+++ b/R/fetch_description.R
@@ -37,7 +37,7 @@
 #' surveys <- all_surveys()
 #'
 #' # Get description for a survey
-#' descrip <- fetch_description(surveyID = surveys$id[6])
+#' descrip <- fetch_description(surveyID = "SV_xxxxxxx1")
 #'
 #' # Get metadata with specific elements
 #' descrip_specific <- fetch_description(

--- a/R/fetch_distribution_history.R
+++ b/R/fetch_distribution_history.R
@@ -14,7 +14,7 @@
 #' )
 #'
 #' surveys <- all_surveys()
-#' distributions <- fetch_distributions(surveys$id[1])
+#' distributions <- fetch_distributions("SV_xxxxxxx1")
 #' distribution_history <- fetch_distribution_history(distributions$id[1])
 #'}
 #'

--- a/R/fetch_distributions.R
+++ b/R/fetch_distributions.R
@@ -15,7 +15,7 @@
 #' )
 #'
 #' surveys <- all_surveys()
-#' distributions <- fetch_distributions(surveys$id[1])
+#' distributions <- fetch_distributions("SV_xxxxxxx1")
 #'}
 #'
 

--- a/R/fetch_survey.R
+++ b/R/fetch_survey.R
@@ -174,10 +174,10 @@
 #' surveys <- all_surveys()
 #'
 #' # Retrieve a single survey
-#' my_survey <- fetch_survey(surveyID = surveys$id[6])
+#' my_survey <- fetch_survey(surveyID = "SV_xxxxxxx1")
 #'
 #' my_survey <- fetch_survey(
-#'   surveyID = surveys$id[6],
+#'   surveyID = "SV_xxxxxxx1",
 #'   start_date = "2018-01-01",
 #'   end_date = "2018-01-31",
 #'   limit = 100,

--- a/R/list_distribution_links.R
+++ b/R/list_distribution_links.R
@@ -15,8 +15,8 @@
 #' )
 #'
 #' surveys <- all_surveys()
-#' distributions <- fetch_distributions(surveys$id[1])
-#' distribution_links <- list_distribution_links(distributions$id[1], surveyID = surveys$id[1])
+#' distributions <- fetch_distributions("SV_xxxxxxx1")
+#' distribution_links <- list_distribution_links(distributions$id[1], surveyID = "SV_xxxxxxx1")
 #'}
 #'
 

--- a/R/metadata.R
+++ b/R/metadata.R
@@ -28,7 +28,7 @@
 #' surveys <- all_surveys()
 #'
 #' # Get metadata for a survey
-#' md <- metadata(surveyID = surveys$id[6])
+#' md <- metadata(surveyID = "SV_xxxxxxx1")
 #'
 #' # Get metadata with specific elements
 #' md_specific <- metadata(

--- a/R/survey_questions.R
+++ b/R/survey_questions.R
@@ -19,11 +19,11 @@
 #' surveys <- all_surveys()
 #'
 #' # Retrieve questions for a survey
-#' questions <- survey_questions(surveyID = surveys$id[6])
+#' questions <- survey_questions(surveyID = "SV_xxxxxxx1")
 #'
 #' # Retrieve a single survey, filtering for specific questions
 #' mysurvey <- fetch_survey(
-#'   surveyID = surveys$id[6],
+#'   surveyID = "SV_xxxxxxx1",
 #'   save_dir = tempdir(),
 #'   include_questions = c("QID1", "QID2", "QID3"),
 #'   verbose = TRUE

--- a/README.Rmd
+++ b/README.Rmd
@@ -101,7 +101,7 @@ surveys <- all_surveys()
 You can then download the data from any of these individual surveys (for example, perhaps the sixth one) directly into R.
 
 ```{r, eval=FALSE}
-mysurvey <- fetch_survey(surveyID = surveys$id[6], 
+mysurvey <- fetch_survey(surveyID = "SV_xxxxxxx1", 
                          verbose = TRUE)
 ```
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ You can then download the data from any of these individual surveys (for
 example, perhaps the sixth one) directly into R.
 
 ``` r
-mysurvey <- fetch_survey(surveyID = surveys$id[6], 
+mysurvey <- fetch_survey(surveyID = "SV_xxxxxxx1", 
                          verbose = TRUE)
 ```
 

--- a/man/all_surveys.Rd
+++ b/man/all_surveys.Rd
@@ -27,10 +27,10 @@ qualtrics_api_credentials(
 surveys <- all_surveys()
 
 # Retrieve a single survey
-mysurvey <- fetch_survey(surveyID = surveys$id[6])
+mysurvey <- fetch_survey(surveyID = "SV_xxxxxxx1")
 
 mysurvey <- fetch_survey(
-  surveyID = surveys$id[6],
+  surveyID = "SV_xxxxxxx1",
   save_dir = tempdir(),
   start_date = "2018-01-01",
   end_date = "2018-01-31",

--- a/man/column_map.Rd
+++ b/man/column_map.Rd
@@ -31,11 +31,11 @@ qualtrics_api_credentials(
 surveys <- all_surveys()
 
 # Retrieve column mapping for a survey
-mapping <- column_map(surveyID = surveys$id[6])
+mapping <- column_map(surveyID = "SV_xxxxxxx1")
 
 # Retrieve a single survey, filtering for specific questions
 mysurvey <- fetch_survey(
-  surveyID = surveys$id[6],
+  surveyID = "SV_xxxxxxx1",
   save_dir = tempdir(),
   include_questions = c("QID1", "QID2", "QID3"),
   verbose = TRUE

--- a/man/extract_colmap.Rd
+++ b/man/extract_colmap.Rd
@@ -26,7 +26,7 @@ on retrying. If you see other types of errors, retrying is unlikely to help.
 surveys <- all_surveys()
 
 # Retrieve a single survey
-mysurvey <- fetch_survey(surveyID = surveys$id[6])
+mysurvey <- fetch_survey(surveyID = "SV_xxxxxxx1")
 
 # Extract column mapping for survey
 extract_colmap(mysurvey)

--- a/man/fetch_description.Rd
+++ b/man/fetch_description.Rd
@@ -50,7 +50,7 @@ qualtrics_api_credentials(
 surveys <- all_surveys()
 
 # Get description for a survey
-descrip <- fetch_description(surveyID = surveys$id[6])
+descrip <- fetch_description(surveyID = "SV_xxxxxxx1")
 
 # Get metadata with specific elements
 descrip_specific <- fetch_description(

--- a/man/fetch_distribution_history.Rd
+++ b/man/fetch_distribution_history.Rd
@@ -27,7 +27,7 @@ qualtrics_api_credentials(
 )
 
 surveys <- all_surveys()
-distributions <- fetch_distributions(surveys$id[1])
+distributions <- fetch_distributions("SV_xxxxxxx1")
 distribution_history <- fetch_distribution_history(distributions$id[1])
 }
 

--- a/man/fetch_distributions.Rd
+++ b/man/fetch_distributions.Rd
@@ -27,7 +27,7 @@ qualtrics_api_credentials(
 )
 
 surveys <- all_surveys()
-distributions <- fetch_distributions(surveys$id[1])
+distributions <- fetch_distributions("SV_xxxxxxx1")
 }
 
 }

--- a/man/fetch_survey.Rd
+++ b/man/fetch_survey.Rd
@@ -225,10 +225,10 @@ qualtrics_api_credentials(
 surveys <- all_surveys()
 
 # Retrieve a single survey
-my_survey <- fetch_survey(surveyID = surveys$id[6])
+my_survey <- fetch_survey(surveyID = "SV_xxxxxxx1")
 
 my_survey <- fetch_survey(
-  surveyID = surveys$id[6],
+  surveyID = "SV_xxxxxxx1",
   start_date = "2018-01-01",
   end_date = "2018-01-31",
   limit = 100,

--- a/man/list_distribution_links.Rd
+++ b/man/list_distribution_links.Rd
@@ -29,8 +29,8 @@ qualtrics_api_credentials(
 )
 
 surveys <- all_surveys()
-distributions <- fetch_distributions(surveys$id[1])
-distribution_links <- list_distribution_links(distributions$id[1], surveyID = surveys$id[1])
+distributions <- fetch_distributions("SV_xxxxxxx1")
+distribution_links <- list_distribution_links(distributions$id[1], surveyID = "SV_xxxxxxx1")
 }
 
 }

--- a/man/metadata.Rd
+++ b/man/metadata.Rd
@@ -42,7 +42,7 @@ qualtrics_api_credentials(
 surveys <- all_surveys()
 
 # Get metadata for a survey
-md <- metadata(surveyID = surveys$id[6])
+md <- metadata(surveyID = "SV_xxxxxxx1")
 
 # Get metadata with specific elements
 md_specific <- metadata(

--- a/man/survey_questions.Rd
+++ b/man/survey_questions.Rd
@@ -31,11 +31,11 @@ qualtrics_api_credentials(
 surveys <- all_surveys()
 
 # Retrieve questions for a survey
-questions <- survey_questions(surveyID = surveys$id[6])
+questions <- survey_questions(surveyID = "SV_xxxxxxx1")
 
 # Retrieve a single survey, filtering for specific questions
 mysurvey <- fetch_survey(
-  surveyID = surveys$id[6],
+  surveyID = "SV_xxxxxxx1",
   save_dir = tempdir(),
   include_questions = c("QID1", "QID2", "QID3"),
   verbose = TRUE

--- a/vignettes/qualtRics.Rmd
+++ b/vignettes/qualtRics.Rmd
@@ -69,10 +69,10 @@ Once your Qualtrics API credentials are stored, you can see what surveys are ava
 surveys <- all_surveys() 
 ```
 
-You can then download the data from any of these individual surveys (for example, perhaps the sixth one) directly into R.
+You can then download the data from any of these individual surveys directly into R. Qualtrics survey IDs start with SV_ followed by a string of numbers and upper- and lower-case letters, e.g., SV_xxxxxxx1. You can either use the survey ID directly or the element from the survey object (for example, surveys$id[6] for the sixth survey ID).
 
 ```{r, eval=FALSE}
-mysurvey <- fetch_survey(surveyID = surveys$id[6], 
+mysurvey <- fetch_survey(surveyID = "SV_xxxxxxx1", 
                          verbose = TRUE)
 ```
 
@@ -81,7 +81,7 @@ mysurvey <- fetch_survey(surveyID = surveys$id[6],
 You can add date parameters to only retrieve responses between certain dates:
 
 ```{r, eval=FALSE}
-mysurvey <- fetch_survey(surveys$id[4],
+mysurvey <- fetch_survey("SV_xxxxxxx1",
                          start_date = "2018-10-01",
                          end_date = "2018-10-31",
                          label = FALSE)
@@ -93,7 +93,7 @@ Note that your date and time settings may not correspond to your own timezone. Y
 You may also reference a response ID; `fetch_survey()` will then download all responses that were submitted after that response:
 
 ```{r eval=FALSE}
-mysurvey <- fetch_survey(surveys$id[4],
+mysurvey <- fetch_survey("SV_xxxxxxx1",
                          last_response = "R_3mmovCIeMllvsER",
                          label = FALSE,
                          verbose = TRUE)
@@ -105,10 +105,10 @@ You can filter a survey for specific questions:
 
 ```{r eval=FALSE}
 # what are the questions in a certain survey?
-questions <- survey_questions(surveyID = surveys$id[6])
+questions <- survey_questions(surveyID = "SV_xxxxxxx1")
 
 # download that survey, filtering for only certain questions
-mysurvey <- fetch_survey(surveyID = surveys$id[6],
+mysurvey <- fetch_survey(surveyID = "SV_xxxxxxx1",
                          save_dir = tempdir(),
                          include_questions = c("QID1", "QID2", "QID3"),
                          verbose = TRUE)
@@ -119,7 +119,7 @@ mysurvey <- fetch_survey(surveyID = surveys$id[6],
 You can store the results in a specific location if you like:
 
 ```{r, eval=FALSE}
-mysurvey <- fetch_survey(surveyID = surveys$id[6], 
+mysurvey <- fetch_survey(surveyID = "SV_xxxxxxx1", 
                          save_dir = "/users/Julia/Desktop/", 
                          verbose = TRUE)
 ```


### PR DESCRIPTION
This PR addresses #341 by replacing `surveys$id[i]` with `"SV_xxxxxxx1"`  in all documentation. This seems like a more robust way to name the survey ID, since deleting surveys could change a particular survey's position in the list of surveys. Therefore, I made the replacement in all instances in the README, vignette, and examples but describe how to use `surveys$id[i]` in the vignette. But I'm happy to alter this, if desired.